### PR TITLE
Linting, part 2, basic formatting compliance

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -31,6 +31,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r yaetos/scripts/requirements_alt.txt
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest --ignore=yaetos/scripts/
+        # TODO: change pytest cmdline above to "pytest tests/ --extraargs?" and find if extraargs exists that gets test running from work dir (i.e. not changing to 'tests/')
     - name: Lint with flake8
       run: |
         pip install flake8
@@ -43,8 +48,3 @@ jobs:
         # info about non-enforced checks. exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         echo 'Rest of formatting not pep8 compliant, not enforced'
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics  # --exit-zero to not block merging if not compliant.
-    - name: Test with pytest
-      run: |
-        pip install pytest
-        pytest --ignore=yaetos/scripts/
-        # TODO: change pytest cmdline above to "pytest tests/ --extraargs?" and find if extraargs exists that gets test running from work dir (i.e. not changing to 'tests/')

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -35,9 +35,14 @@ jobs:
       run: |
         pip install flake8
         # stop the build if there are Python syntax errors or undefined names
+        echo 'Syntax errors or undefined names, enforced'
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --ignore=E501,C901,E402,W605 --max-complexity=10 --max-line-length=127 --statistics  # TODO: remove  --exit-zero to enforce, and check to remove --ignore codes.
+        # enforce all rules except these below
+        echo 'Code formatting not compliant, enforced'
+        flake8 . --count --ignore=E501,C901,E402,W605, F401 --max-complexity=10 --max-line-length=127 --statistics
+        # info about non-enforced checks. exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        echo 'Rest of formatting not pep8 compliant, not enforced'
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics  # --exit-zero to not block merging if not compliant. TODO: check to remove "--ignore" codes.
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -39,7 +39,7 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # enforce all rules except these below
         echo 'Code formatting not compliant, enforced'
-        flake8 . --count --ignore=E501,C901,E402,W605, F401 --max-complexity=10 --max-line-length=127 --statistics  # TODO: check to remove "--ignore" codes.
+        flake8 . --count --ignore=E501,C901,E402,W605,F401,F841 --max-complexity=10 --max-line-length=127 --statistics  # TODO: check to remove "--ignore" codes.
         # info about non-enforced checks. exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         echo 'Rest of formatting not pep8 compliant, not enforced'
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics  # --exit-zero to not block merging if not compliant.

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -39,10 +39,10 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # enforce all rules except these below
         echo 'Code formatting not compliant, enforced'
-        flake8 . --count --ignore=E501,C901,E402,W605, F401 --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --ignore=E501,C901,E402,W605, F401 --max-complexity=10 --max-line-length=127 --statistics  # TODO: check to remove "--ignore" codes.
         # info about non-enforced checks. exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         echo 'Rest of formatting not pep8 compliant, not enforced'
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics  # --exit-zero to not block merging if not compliant. TODO: check to remove "--ignore" codes.
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics  # --exit-zero to not block merging if not compliant.
     - name: Test with pytest
       run: |
         pip install pytest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ templates_path = ['_templates']
 
 # -- Options for HTML output
 
-html_theme = 'alabaster' #default: 'sphinx_rtd_theme'
+html_theme = 'alabaster'  # default: 'sphinx_rtd_theme'
 html_theme_options = {
     'show_powered_by': False,
     'github_user': 'arthurprevot',
@@ -39,7 +39,7 @@ html_theme_options = {
     'github_button': True,
     'show_related': False,
     'note_bg': '#FFF59C'
-} # TODO: add "Fork me on github" banner with 'sphinx_rtd_theme' theme, using _template, see https://stackoverflow.com/questions/53327826/how-to-add-fork-me-on-github-ribbon-using-sphinx-and-readthedocs-theme
+}  # TODO: add "Fork me on github" banner with 'sphinx_rtd_theme' theme, using _template, see https://stackoverflow.com/questions/53327826/how-to-add-fork-me-on-github-ribbon-using-sphinx-and-readthedocs-theme
 
 # -- Options for EPUB output
 epub_show_urls = 'footnote'

--- a/jobs/examples/ex0_extraction_job.py
+++ b/jobs/examples/ex0_extraction_job.py
@@ -13,8 +13,8 @@ class Job(ETL_Base):
 
         # Save to local
         tmp_dir = 'tmp'
-        os.makedirs(tmp_dir, exist_ok = True)
-        local_path = tmp_dir+'/tmp_file.csv.gz'
+        os.makedirs(tmp_dir, exist_ok=True)
+        local_path = tmp_dir + '/tmp_file.csv.gz'
         open(local_path, 'wb').write(resp.content)  # creating local copy, necessary for sc_sql.read.csv, TODO: check to remove local copy step.
         self.logger.info('Copied file locally at {}.'.format(local_path))
 

--- a/jobs/examples/ex10_troubleshoot_job.py
+++ b/jobs/examples/ex10_troubleshoot_job.py
@@ -13,7 +13,7 @@ class Job(ETL_Base):
             order by count(*) desc
             """)
 
-        import ipdb; ipdb.set_trace()  # will drop to python terminal here to inspect
+        import ipdb; ipdb.set_trace()  # will drop to python terminal here to inspect  # noqa: E702
 
         return df
 

--- a/jobs/examples/ex2_frameworked_job.py
+++ b/jobs/examples/ex2_frameworked_job.py
@@ -59,8 +59,8 @@ class Job(ETL_Base):
         return '{year}-{month}-{day} {hour}:{minute}:{sec}'.format(**dt)
 
     @staticmethod
-    def date_diff_sec(x,y):
-        return int((y-x).total_seconds())
+    def date_diff_sec(x, y):
+        return int((y - x).total_seconds())
 
 
 if __name__ == "__main__":

--- a/jobs/examples/ex2_frameworked_job.py
+++ b/jobs/examples/ex2_frameworked_job.py
@@ -19,7 +19,7 @@ class Job(ETL_Base):
 
         events_cleaned = df \
             .withColumn('timestamp_obj', udf_format_datetime(df.timestamp).cast("timestamp")) \
-            .where(col('timestamp').like("%2.016%") == False)
+            .where(col('timestamp').like("%2.016%") is False)
 
         events_cleaned.createOrReplaceTempView("events_cleaned")
 

--- a/jobs/examples/ex3_incremental_prep_job.py
+++ b/jobs/examples/ex3_incremental_prep_job.py
@@ -27,5 +27,5 @@ class Job(ETL_Base):
 
 
 if __name__ == "__main__":
-    args = {'job_param_file':   'conf/jobs_metadata.yml'}
+    args = {'job_param_file': 'conf/jobs_metadata.yml'}
     Commandliner(Job, **args)

--- a/jobs/examples/ex3_incremental_prep_job.py
+++ b/jobs/examples/ex3_incremental_prep_job.py
@@ -11,7 +11,7 @@ class Job(ETL_Base):
 
         events_cleaned = some_events \
             .withColumn('timestamp_obj', udf_format_datetime(some_events.timestamp).cast("timestamp")) \
-            .where(col('timestamp').like("%2.016%") == False)
+            .where(col('timestamp').like("%2.016%") is False)
         return events_cleaned
 
     @staticmethod

--- a/jobs/examples/ex5_copy_to_oracle_job.py
+++ b/jobs/examples/ex5_copy_to_oracle_job.py
@@ -6,7 +6,7 @@ class Job(ETL_Base):
     OUTPUT_TYPES = {
         'session_id': types.VARCHAR(16),
         'count_events': types.INT(),
-        }
+    }
 
     def transform(self, some_events, other_events):
         df = self.query("""

--- a/jobs/examples/ex5_copy_to_redshift_job.py
+++ b/jobs/examples/ex5_copy_to_redshift_job.py
@@ -6,7 +6,7 @@ class Job(ETL_Base):
     OUTPUT_TYPES = {
         'session_id': types.VARCHAR(16),
         'count_events': types.INT(),
-        }
+    }
 
     def transform(self, some_events, other_events):
         df = self.query("""

--- a/jobs/examples/ex5_input_from_oracle_job.py
+++ b/jobs/examples/ex5_input_from_oracle_job.py
@@ -9,7 +9,7 @@ class Job(ETL_Base):
     OUTPUT_TYPES = {
         'session_id': types.VARCHAR(16),
         'count_events': types.INT(),
-        }
+    }
 
     def transform(self):
         cred_profiles = Cred_Ops_Dispatcher().retrieve_secrets(self.jargs.storage)

--- a/jobs/examples/ex7_extraction_small_job.py
+++ b/jobs/examples/ex7_extraction_small_job.py
@@ -2,6 +2,8 @@
 from yaetos.etl_utils import ETL_Base, Commandliner
 
 # TODO: move it to .sql job.
+
+
 class Job(ETL_Base):
     def transform(self, events):
         df = self.query("""

--- a/jobs/examples/ex7_hybrid_pandas_spark_job.py
+++ b/jobs/examples/ex7_hybrid_pandas_spark_job.py
@@ -18,10 +18,10 @@ class Job(ETL_Base):
 
         # Transformation in pandas
         some_events_pd = some_events_pd[:1000]
-        df1 = some_events_pd[some_events_pd.apply(lambda row: row['action'] == 'searchResultPage' and float(row['n_results'])>0, axis=1)]
-        df2 = pd.merge(left=df1, right=other_events_pd, how='inner', left_on='session_id', right_on='session_id', indicator = True, suffixes=('_1', '_2'))
+        df1 = some_events_pd[some_events_pd.apply(lambda row: row['action'] == 'searchResultPage' and float(row['n_results']) > 0, axis=1)]
+        df2 = pd.merge(left=df1, right=other_events_pd, how='inner', left_on='session_id', right_on='session_id', indicator=True, suffixes=('_1', '_2'))
         df3 = df2.groupby(by=['session_id']).agg({'_merge': np.count_nonzero})
-        df3.rename(columns={'_merge':'count_events'}, inplace=True)
+        df3.rename(columns={'_merge': 'count_events'}, inplace=True)
         df3.sort_values('count_events', ascending=False, inplace=True)
         df3.reset_index(drop=False, inplace=True)
         self.logger.info('Post filter length: {}'.format(len(df1)))

--- a/jobs/examples/ex7_pandas_job.py
+++ b/jobs/examples/ex7_pandas_job.py
@@ -10,11 +10,11 @@ import numpy as np
 
 class Job(ETL_Base):
     def transform(self, some_events, other_events):
-        some_events = some_events[:1000]  # to speed up since it is an example job 
-        df1 = some_events[some_events.apply(lambda row: row['action'] == 'searchResultPage' and float(row['n_results'])>0, axis=1)]
-        df2 = pd.merge(left=df1, right=other_events, how='inner', left_on='session_id', right_on='session_id', indicator = True, suffixes=('_1', '_2'))
+        some_events = some_events[:1000]  # to speed up since it is an example job
+        df1 = some_events[some_events.apply(lambda row: row['action'] == 'searchResultPage' and float(row['n_results']) > 0, axis=1)]
+        df2 = pd.merge(left=df1, right=other_events, how='inner', left_on='session_id', right_on='session_id', indicator=True, suffixes=('_1', '_2'))
         df3 = df2.groupby(by=['session_id']).agg({'_merge': np.count_nonzero})
-        df3.rename(columns={'_merge':'count_events'}, inplace=True)
+        df3.rename(columns={'_merge': 'count_events'}, inplace=True)
         df3.sort_values('count_events', ascending=False, inplace=True)
         df3.reset_index(drop=False, inplace=True)
         self.logger.info('Post filter length: {}'.format(len(df1)))

--- a/jobs/examples/ex8_koalas_job.py
+++ b/jobs/examples/ex8_koalas_job.py
@@ -4,6 +4,7 @@ import pandas as pd
 import numpy as np
 import databricks.koalas as ks
 
+
 class Job(ETL_Base):
     def transform(self, some_events, other_events):
         # Convert spark df to koalas df
@@ -11,9 +12,9 @@ class Job(ETL_Base):
         oe_kdf = other_events.to_koalas()
 
         # processing
-        se_kdf = se_kdf[se_kdf['action']=='searchResultPage']
-        se_kdf = se_kdf[se_kdf['n_results']>0]
-        merged_kdf = ks.merge(se_kdf, oe_kdf, on='session_id', how='inner', suffixes=('_l','_r'))
+        se_kdf = se_kdf[se_kdf['action'] == 'searchResultPage']
+        se_kdf = se_kdf[se_kdf['n_results'] > 0]
+        merged_kdf = ks.merge(se_kdf, oe_kdf, on='session_id', how='inner', suffixes=('_l', '_r'))
         grouped = merged_kdf.groupby(by=['session_id']).count()
 
         # back to spark df

--- a/jobs/examples/ex9_clickhouse_job.py
+++ b/jobs/examples/ex9_clickhouse_job.py
@@ -31,5 +31,5 @@ class Job(ETL_Base):
 if __name__ == "__main__":
     args = {'job_param_file': 'conf/jobs_metadata.yml',
             'load_connectors': 'all',
-    }
+            }
     Commandliner(Job, **args)

--- a/jobs/generic/dummy_job.py
+++ b/jobs/generic/dummy_job.py
@@ -1,6 +1,7 @@
 from yaetos.etl_utils import ETL_Base, Commandliner
 from pyspark.sql.types import StructType
 
+
 class Job(ETL_Base):
     def transform(self):
         return self.sc_sql.createDataFrame([], StructType([]))

--- a/jobs/generic/launcher.py
+++ b/jobs/generic/launcher.py
@@ -5,4 +5,4 @@ Usage: $ python jobs/generic/launcher.py --job_name=some_job_name_from_manifest
 
 from yaetos.etl_utils import Commandliner
 
-Commandliner(Job=None, launcher_file = 'jobs/generic/launcher.py')
+Commandliner(Job=None, launcher_file='jobs/generic/launcher.py')

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup(
     #
     #   py_modules=["my_module"],
     #
-    #packages=find_packages(where='core'),  # Required
+    # packages=find_packages(where='core'),  # Required
     packages=[
         'yaetos',
         'yaetos.libs.analysis_toolkit',
@@ -142,7 +142,7 @@ setup(
         'yaetos.libs.generic_jobs',
         'yaetos.scripts',
         'yaetos.scripts.copy',
-        ],  # Required
+    ],  # Required
 
     # Specify which Python versions you support. In contrast to the
     # 'Programming Language' classifiers above, 'pip install' will check this

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,34 +8,38 @@ import pytest
 from pyspark import SparkContext
 from pyspark.sql import SQLContext, SparkSession, Row
 
+
 @pytest.fixture(scope="session")
 def sc(request):
     sc = SparkContext(appName='test')
     return sc
 
+
 @pytest.fixture(scope="session")
 def sc_sql(sc):
     return SQLContext(sc)
+
 
 @pytest.fixture(scope="session")
 def ss(sc):  # TODO: check if sc necessary here since not used downstream
     return SparkSession.builder.appName('test').getOrCreate()
 
+
 @pytest.fixture
 def get_pre_jargs():
     def internal_function(input_names=[], pre_jargs_over={}):
         """Requires loaded_inputs or pre_jargs_over"""
-        inputs  = {key: {'type':None} for key in input_names}
+        inputs = {key: {'type': None} for key in input_names}
         pre_jargs = {
             'defaults_args': {
                 'manage_git_info': False,
-                'mode':'dev_local',
-                'deploy':'none',
-                'job_param_file':None,
-                'output': {'type':None},
+                'mode': 'dev_local',
+                'deploy': 'none',
+                'job_param_file': None,
+                'output': {'type': None},
                 'inputs': inputs},
-            'job_args':{},
-            'cmd_args':{}}
+            'job_args': {},
+            'cmd_args': {}}
         if 'defaults_args' in pre_jargs_over.keys():
             pre_jargs['defaults_args'].update(pre_jargs_over['defaults_args'])
         else:

--- a/tests/jobs/examples/ex1_frameworked_job_test.py
+++ b/tests/jobs/examples/ex1_frameworked_job_test.py
@@ -7,7 +7,7 @@ class Test_Job(object):
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1235, 'action': 'searchResultPage', 'n_results': 1},
-            {'session_id': 1236, 'action': 'other',            'n_results': 1},
+            {'session_id': 1236, 'action': 'other',            'n_results': 1},  # noqa: E241
         ]))
 
         other_events = ss.read.json(sc.parallelize([

--- a/tests/jobs/examples/ex1_frameworked_job_test.py
+++ b/tests/jobs/examples/ex1_frameworked_job_test.py
@@ -8,20 +8,20 @@ class Test_Job(object):
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1235, 'action': 'searchResultPage', 'n_results': 1},
-            {'session_id': 1236, 'action': 'other',            'n_results': 1},
-            ]))
+            {'session_id': 1236, 'action': 'other', 'n_results': 1},
+        ]))
 
         other_events = ss.read.json(sc.parallelize([
             {'session_id': 1234, 'other': 1},
             {'session_id': 1235, 'other': 1},
             {'session_id': 1236, 'other': 1},
-            ]))
+        ]))
 
         expected = [
             {'session_id': 1234, 'count_events': 2},
             {'session_id': 1235, 'count_events': 1},
-            ]
+        ]
 
-        loaded_inputs={'some_events': some_events, 'other_events':other_events}
+        loaded_inputs = {'some_events': some_events, 'other_events': other_events}
         actual = Job(pre_jargs=get_pre_jargs(loaded_inputs.keys())).etl_no_io(sc, sc_sql, loaded_inputs=loaded_inputs)[0].toPandas().to_dict(orient='records')
         assert actual == expected

--- a/tests/jobs/examples/ex1_frameworked_job_test.py
+++ b/tests/jobs/examples/ex1_frameworked_job_test.py
@@ -1,4 +1,3 @@
-import pytest
 from jobs.examples.ex1_frameworked_job import Job
 
 
@@ -8,7 +7,7 @@ class Test_Job(object):
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1235, 'action': 'searchResultPage', 'n_results': 1},
-            {'session_id': 1236, 'action': 'other', 'n_results': 1},
+            {'session_id': 1236, 'action': 'other',            'n_results': 1},
         ]))
 
         other_events = ss.read.json(sc.parallelize([

--- a/tests/jobs/examples/ex1_full_sql_job_test.py
+++ b/tests/jobs/examples/ex1_full_sql_job_test.py
@@ -8,23 +8,23 @@ class Test_Job(object):
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1235, 'action': 'searchResultPage', 'n_results': 1},
-            {'session_id': 1236, 'action': 'other',            'n_results': 1},
-            ]))
+            {'session_id': 1236, 'action': 'other', 'n_results': 1},
+        ]))
 
         other_events = ss.read.json(sc.parallelize([
             {'session_id': 1234, 'other': 1},
             {'session_id': 1235, 'other': 1},
             {'session_id': 1236, 'other': 1},
-            ]))
+        ]))
 
         expected = [
             {'session_id': 1234, 'count_events': 2},
             {'session_id': 1235, 'count_events': 1},
-            ]
+        ]
 
         sql_file = 'jobs/examples/ex1_full_sql_job.sql'
 
-        loaded_inputs={'some_events': some_events, 'other_events':other_events}
+        loaded_inputs = {'some_events': some_events, 'other_events': other_events}
         pre_jargs = get_pre_jargs(loaded_inputs.keys())
         pre_jargs['cmd_args']['sql_file'] = sql_file
         actual = Job(pre_jargs=pre_jargs).etl_no_io(sc, sc_sql, loaded_inputs=loaded_inputs)[0].toPandas().to_dict(orient='records')

--- a/tests/jobs/examples/ex1_full_sql_job_test.py
+++ b/tests/jobs/examples/ex1_full_sql_job_test.py
@@ -1,4 +1,3 @@
-import pytest
 from yaetos.sql_job import Job
 
 
@@ -8,7 +7,7 @@ class Test_Job(object):
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1235, 'action': 'searchResultPage', 'n_results': 1},
-            {'session_id': 1236, 'action': 'other', 'n_results': 1},
+            {'session_id': 1236, 'action': 'other',            'n_results': 1},  # noqa: E241
         ]))
 
         other_events = ss.read.json(sc.parallelize([

--- a/tests/jobs/examples/ex4_dependency1_job_test.py
+++ b/tests/jobs/examples/ex4_dependency1_job_test.py
@@ -1,4 +1,3 @@
-import pytest
 from jobs.examples.ex4_dependency1_job import Job
 
 
@@ -12,9 +11,9 @@ class Test_Job(object):
         ]))
 
         expected = [
-            {'session_id': 1, 'session_length': 1},
-            {'session_id': 12, 'session_length': 2},
-            {'session_id': 123, 'session_length': 3},
+            {'session_id': 1,    'session_length': 1},  # noqa: E241
+            {'session_id': 12,   'session_length': 2},  # noqa: E241
+            {'session_id': 123,  'session_length': 3},  # noqa: E241
             {'session_id': 1234, 'session_length': 4},
         ]
 

--- a/tests/jobs/examples/ex4_dependency1_job_test.py
+++ b/tests/jobs/examples/ex4_dependency1_job_test.py
@@ -9,15 +9,15 @@ class Test_Job(object):
             {'session_id': 12},
             {'session_id': 123},
             {'session_id': 1234},
-            ]))
+        ]))
 
         expected = [
             {'session_id': 1, 'session_length': 1},
             {'session_id': 12, 'session_length': 2},
             {'session_id': 123, 'session_length': 3},
             {'session_id': 1234, 'session_length': 4},
-            ]
+        ]
 
-        loaded_inputs={'some_events': some_events}
+        loaded_inputs = {'some_events': some_events}
         actual = Job(pre_jargs=get_pre_jargs(loaded_inputs.keys())).etl_no_io(sc, sc_sql, loaded_inputs=loaded_inputs)[0].toPandas().to_dict(orient='records')
         assert actual == expected

--- a/tests/jobs/examples/ex4_dependency2_job_test.py
+++ b/tests/jobs/examples/ex4_dependency2_job_test.py
@@ -9,15 +9,15 @@ class Test_Job(object):
             {'session_id': 12, 'session_length': 2},
             {'session_id': 123, 'session_length': 3},
             {'session_id': 1234, 'session_length': 4},
-            ]))
+        ]))
 
         expected = [
-            {'session_id': 1,    'session_length': 1, 'doubled_length': 2},
-            {'session_id': 12,   'session_length': 2, 'doubled_length': 4},
-            {'session_id': 123,  'session_length': 3, 'doubled_length': 6},
+            {'session_id': 1, 'session_length': 1, 'doubled_length': 2},
+            {'session_id': 12, 'session_length': 2, 'doubled_length': 4},
+            {'session_id': 123, 'session_length': 3, 'doubled_length': 6},
             {'session_id': 1234, 'session_length': 4, 'doubled_length': 8},
-            ]
+        ]
 
-        loaded_inputs={'some_events': some_events}
+        loaded_inputs = {'some_events': some_events}
         actual = Job(pre_jargs=get_pre_jargs(loaded_inputs.keys())).etl_no_io(sc, sc_sql, loaded_inputs=loaded_inputs)[0].toPandas().to_dict(orient='records')
         assert actual == expected

--- a/tests/jobs/examples/ex4_dependency2_job_test.py
+++ b/tests/jobs/examples/ex4_dependency2_job_test.py
@@ -1,4 +1,3 @@
-import pytest
 from jobs.examples.ex4_dependency2_job import Job
 
 
@@ -12,9 +11,9 @@ class Test_Job(object):
         ]))
 
         expected = [
-            {'session_id': 1, 'session_length': 1, 'doubled_length': 2},
-            {'session_id': 12, 'session_length': 2, 'doubled_length': 4},
-            {'session_id': 123, 'session_length': 3, 'doubled_length': 6},
+            {'session_id': 1,    'session_length': 1, 'doubled_length': 2},  # noqa: E241
+            {'session_id': 12,   'session_length': 2, 'doubled_length': 4},  # noqa: E241
+            {'session_id': 123,  'session_length': 3, 'doubled_length': 6},  # noqa: E241
             {'session_id': 1234, 'session_length': 4, 'doubled_length': 8},
         ]
 

--- a/tests/jobs/examples/ex4_dependency4_job_test.py
+++ b/tests/jobs/examples/ex4_dependency4_job_test.py
@@ -19,7 +19,7 @@ def test_job(sc, sc_sql, ss, get_pre_jargs):
         'job_param_file': 'conf/jobs_metadata.yml',
         'base_path': './tests/fixtures/data_sample/',
         'dependencies': True,
-        'add_created_at':False,
+        'add_created_at': False,
         'parse_cmdline': False}
     job = Runner(Job, **args).run()
     path = job.jargs.output['path_expanded']

--- a/tests/jobs/examples/ex4_dependency4_job_test.py
+++ b/tests/jobs/examples/ex4_dependency4_job_test.py
@@ -2,7 +2,6 @@
 More integration-test than unit-test. This runs pipeline with 4 jobs, loading data from file system and dropping to file system for each one.
 Code here reusable directly in jupyter notebooks.
 """
-import pytest
 from jobs.examples.ex4_dependency4_job import Job
 from yaetos.etl_utils import Runner
 from yaetos.pandas_utils import load_csvs

--- a/tests/jobs/examples/ex7_hybrid_pandas_spark_job_test.py
+++ b/tests/jobs/examples/ex7_hybrid_pandas_spark_job_test.py
@@ -8,21 +8,21 @@ class Test_Job(object):
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1235, 'action': 'searchResultPage', 'n_results': 1},
-            {'session_id': 1236, 'action': 'other',            'n_results': 1},
-            ]))
+            {'session_id': 1236, 'action': 'other', 'n_results': 1},
+        ]))
 
         other_events = ss.read.json(sc.parallelize([
             {'session_id': 1234, 'other': 1},
             {'session_id': 1235, 'other': 1},
             {'session_id': 1236, 'other': 1},
-            ]))
+        ]))
 
         expected = [
             {'session_id': '1234', 'count_events': 2},
             {'session_id': '1235', 'count_events': 1},
             # only diff with ex1_framework_job is session_id being str instead of int.
-            ]
+        ]
 
-        loaded_inputs={'some_events': some_events, 'other_events':other_events}
+        loaded_inputs = {'some_events': some_events, 'other_events': other_events}
         actual = Job(pre_jargs=get_pre_jargs(loaded_inputs.keys())).etl_no_io(sc, sc_sql, loaded_inputs=loaded_inputs)[0].toPandas().to_dict(orient='records')
         assert actual == expected

--- a/tests/jobs/examples/ex7_hybrid_pandas_spark_job_test.py
+++ b/tests/jobs/examples/ex7_hybrid_pandas_spark_job_test.py
@@ -1,4 +1,3 @@
-import pytest
 from jobs.examples.ex7_hybrid_pandas_spark_job import Job
 
 
@@ -8,7 +7,7 @@ class Test_Job(object):
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1235, 'action': 'searchResultPage', 'n_results': 1},
-            {'session_id': 1236, 'action': 'other', 'n_results': 1},
+            {'session_id': 1236, 'action': 'other',            'n_results': 1},  # noqa: E241
         ]))
 
         other_events = ss.read.json(sc.parallelize([

--- a/tests/jobs/examples/ex7_pandas_job_test.py
+++ b/tests/jobs/examples/ex7_pandas_job_test.py
@@ -9,21 +9,21 @@ class Test_Job(object):
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1235, 'action': 'searchResultPage', 'n_results': 1},
-            {'session_id': 1236, 'action': 'other',            'n_results': 1},
-            ])
+            {'session_id': 1236, 'action': 'other', 'n_results': 1},
+        ])
 
         other_events = pd.DataFrame([
             {'session_id': 1234, 'other': 1},
             {'session_id': 1235, 'other': 1},
             {'session_id': 1236, 'other': 1},
-            ])
+        ])
 
         expected = [
             {'session_id': 1234, 'count_events': 2},
             {'session_id': 1235, 'count_events': 1},
             # only diff with ex1_framework_job is session_id being str instead of int.
-            ]
+        ]
 
-        loaded_inputs={'some_events': some_events, 'other_events':other_events}
+        loaded_inputs = {'some_events': some_events, 'other_events': other_events}
         actual = Job(pre_jargs=get_pre_jargs(loaded_inputs.keys())).etl_no_io(sc=None, sc_sql=None, loaded_inputs=loaded_inputs)[0].to_dict(orient='records')
         assert actual == expected

--- a/tests/jobs/examples/ex7_pandas_job_test.py
+++ b/tests/jobs/examples/ex7_pandas_job_test.py
@@ -1,4 +1,3 @@
-import pytest
 from jobs.examples.ex7_pandas_job import Job
 import pandas as pd
 
@@ -9,7 +8,7 @@ class Test_Job(object):
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1235, 'action': 'searchResultPage', 'n_results': 1},
-            {'session_id': 1236, 'action': 'other', 'n_results': 1},
+            {'session_id': 1236, 'action': 'other',            'n_results': 1},  # noqa: E241
         ])
 
         other_events = pd.DataFrame([

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -27,7 +27,7 @@ class Test_ETL_Base(object):
 
     def test_set_py_job(self, get_pre_jargs):
         py_job = ETL_Base(pre_jargs=get_pre_jargs({})).set_py_job()
-        assert py_job == LOCAL_JOB_FOLDER+'yaetos/etl_utils.py' # file is the one that starts execution, typically the job python file.
+        assert py_job == LOCAL_JOB_FOLDER + 'yaetos/etl_utils.py'  # file is the one that starts execution, typically the job python file.
 
     def test_load_inputs(self, sc, sc_sql, ss, get_pre_jargs):
         """Confirming load_inputs acts as a passthrough"""
@@ -35,7 +35,7 @@ class Test_ETL_Base(object):
             {'id': 1},
             {'id': 2},
             {'id': 3}]))
-        loaded_inputs = {'input1':sdf}
+        loaded_inputs = {'input1': sdf}
         app_args_expected = loaded_inputs
         assert ETL_Base(pre_jargs=get_pre_jargs(loaded_inputs.keys())).load_inputs(loaded_inputs) == app_args_expected
 
@@ -46,8 +46,8 @@ class Test_ETL_Base(object):
             {'id': 3, 'timestamp': '2020-01-03'}]))
         pre_jargs_over = {
             'defaults_args': {
-                'inputs':{},
-                'output': {'inc_field': 'timestamp', 'type':None}}}
+                'inputs': {},
+                'output': {'inc_field': 'timestamp', 'type': None}}}
         max_timestamp_expected = '2020-01-03'
         assert ETL_Base(pre_jargs=get_pre_jargs(pre_jargs_over=pre_jargs_over)).get_max_timestamp(sdf) == max_timestamp_expected
 
@@ -87,7 +87,7 @@ class Test_Job_Yml_Parser(object):
         job_name = Job_Yml_Parser.set_job_name_from_file('jobs/some/file.py')
         assert job_name == 'some/file.py'
 
-        job_name = Job_Yml_Parser.set_job_name_from_file(LOCAL_JOB_FOLDER+'jobs/some/file.py')
+        job_name = Job_Yml_Parser.set_job_name_from_file(LOCAL_JOB_FOLDER + 'jobs/some/file.py')
         assert job_name == 'some/file.py'
 
     # def test_set_sql_file_from_name(self) # to be added
@@ -96,7 +96,7 @@ class Test_Job_Yml_Parser(object):
 
 class Test_Job_Args_Parser(object):
     def test_no_param_override(self):
-        defaults_args = {'mode': 'dev_local', 'deploy':'code', 'output': {'path':'n/a', 'type': 'csv'}}
+        defaults_args = {'mode': 'dev_local', 'deploy': 'code', 'output': {'path': 'n/a', 'type': 'csv'}}
         expected_args = {**{'inputs': {}, 'is_incremental': False}, **defaults_args}
 
         jargs = Job_Args_Parser(defaults_args=defaults_args, yml_args={}, job_args={}, cmd_args={})
@@ -111,7 +111,7 @@ class Test_Flow(object):
             'job_param_file': JOBS_METADATA_FILE,
             'job_name': 'examples/ex4_dependency2_job.py',
             'storage': 'local',
-            }
+        }
         launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args={}, cmd_args=cmd_args, loaded_inputs={})
         connection_real = Flow.create_connections_jobs(launch_jargs.storage, launch_jargs.merged_args)
         connection_expected = pd.DataFrame(
@@ -126,8 +126,8 @@ class Test_Flow(object):
                 ['examples/ex4_dependency1_job.py', 'examples/ex4_dependency3_job.sql'],
                 ['examples/ex4_dependency3_job.sql', 'examples/ex4_dependency4_job.py'],
                 ['examples/ex0_extraction_job.py', 'examples/ex7_extraction_small_job.py'],
-                ]),
-            )
+            ]),
+        )
         assert_frame_equal(connection_real, connection_expected)
 
     def test_create_global_graph(self):
@@ -140,7 +140,7 @@ class Test_Flow(object):
                 ['examples/ex4_dependency2_job.py', 'examples/ex4_dependency3_job.sql'],
                 ['examples/ex4_dependency1_job.py', 'examples/ex4_dependency3_job.sql'],
                 ['examples/ex4_dependency3_job.sql', 'examples/ex4_dependency4_job.py']]),
-            )
+        )
         nx_real = Flow.create_global_graph(df)
         nx_expected = {
             'examples/ex3_incremental_prep_job.py': {'examples/ex3_incremental_job.py': {}},
@@ -149,7 +149,7 @@ class Test_Flow(object):
             'examples/ex4_dependency2_job.py': {'examples/ex4_dependency3_job.sql': {}},
             'examples/ex4_dependency3_job.sql': {'examples/ex4_dependency4_job.py': {}},
             'examples/ex4_dependency4_job.py': {}
-            }
+        }
         # Other way to check graph equality: nx.is_isomorphic(nx_real, nx_expected)
         assert nx.to_dict_of_dicts(nx_real) == nx_expected
 

--- a/tests/yaetos/pandas_utils_test.py
+++ b/tests/yaetos/pandas_utils_test.py
@@ -6,84 +6,87 @@ import numpy as np
 from yaetos.pandas_utils import load_multiple_csvs, load_csvs, \
     load_multiple_files, load_df, save_pandas_local
 
+
 def test_load_csvs():
     # Test multiple file option
     path = 'tests/fixtures/data_sample/wiki_example/input/'
     actual = load_csvs(path, read_kwargs={})
     expected = pd.DataFrame([
-        {'uuid':'u1','timestamp':2.0,'session_id':'s1','group': 'g1','action':'searchResultPage','checkin':np.nan,'page_id':'p1','n_results':5.0,'result_position':np.nan},
-        {'uuid':'u2','timestamp':2.0,'session_id':'s2','group': 'g2','action':'searchResultPage','checkin':np.nan,'page_id':'p2','n_results':9.0,'result_position':np.nan},
-        {'uuid':'u3','timestamp':2.0,'session_id':'s3','group': 'g3','action':'checkin',         'checkin':30,    'page_id':'p3','n_results':np.nan,'result_position':np.nan},
-        {'uuid':'u4','timestamp':2.0,'session_id':'s1','group': 'g1','action':'searchResultPage','checkin':np.nan,'page_id':'p1','n_results':5.0,'result_position':np.nan},
-        {'uuid':'u5','timestamp':2.0,'session_id':'s2','group': 'g2','action':'searchResultPage','checkin':np.nan,'page_id':'p2','n_results':9.0,'result_position':np.nan},
-        {'uuid':'u6','timestamp':2.0,'session_id':'s3','group': 'g3','action':'checkin',         'checkin':30,    'page_id':'p3','n_results':np.nan,'result_position':np.nan},
-        ])
+        {'uuid': 'u1', 'timestamp': 2.0, 'session_id': 's1', 'group': 'g1', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p1', 'n_results': 5.0, 'result_position': np.nan},
+        {'uuid': 'u2', 'timestamp': 2.0, 'session_id': 's2', 'group': 'g2', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p2', 'n_results': 9.0, 'result_position': np.nan},
+        {'uuid': 'u3', 'timestamp': 2.0, 'session_id': 's3', 'group': 'g3', 'action': 'checkin', 'checkin': 30, 'page_id': 'p3', 'n_results': np.nan, 'result_position': np.nan},
+        {'uuid': 'u4', 'timestamp': 2.0, 'session_id': 's1', 'group': 'g1', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p1', 'n_results': 5.0, 'result_position': np.nan},
+        {'uuid': 'u5', 'timestamp': 2.0, 'session_id': 's2', 'group': 'g2', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p2', 'n_results': 9.0, 'result_position': np.nan},
+        {'uuid': 'u6', 'timestamp': 2.0, 'session_id': 's3', 'group': 'g3', 'action': 'checkin', 'checkin': 30, 'page_id': 'p3', 'n_results': np.nan, 'result_position': np.nan},
+    ])
     assert_frame_equal(actual, expected)
 
     # Test single file option
     path = 'tests/fixtures/data_sample/wiki_example/input/part1.csv'
     actual = load_csvs(path, read_kwargs={})
     expected = pd.DataFrame([
-        {'uuid':'u1','timestamp':2.0,'session_id':'s1','group': 'g1','action':'searchResultPage','checkin':np.nan,'page_id':'p1','n_results':5.0,'result_position':np.nan},
-        {'uuid':'u2','timestamp':2.0,'session_id':'s2','group': 'g2','action':'searchResultPage','checkin':np.nan,'page_id':'p2','n_results':9.0,'result_position':np.nan},
-        {'uuid':'u3','timestamp':2.0,'session_id':'s3','group': 'g3','action':'checkin',         'checkin':30,    'page_id':'p3','n_results':np.nan,'result_position':np.nan},
-        ])
+        {'uuid': 'u1', 'timestamp': 2.0, 'session_id': 's1', 'group': 'g1', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p1', 'n_results': 5.0, 'result_position': np.nan},
+        {'uuid': 'u2', 'timestamp': 2.0, 'session_id': 's2', 'group': 'g2', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p2', 'n_results': 9.0, 'result_position': np.nan},
+        {'uuid': 'u3', 'timestamp': 2.0, 'session_id': 's3', 'group': 'g3', 'action': 'checkin', 'checkin': 30, 'page_id': 'p3', 'n_results': np.nan, 'result_position': np.nan},
+    ])
     assert_frame_equal(actual, expected)
+
 
 def test_load_df():
     # Test multiple file option
     path = 'tests/fixtures/data_sample/wiki_example/input/'
     actual = load_df(path, file_type='csv', read_func='read_csv', read_kwargs={})
     expected = pd.DataFrame([
-        {'uuid':'u1','timestamp':2.0,'session_id':'s1','group': 'g1','action':'searchResultPage','checkin':np.nan,'page_id':'p1','n_results':5.0,'result_position':np.nan},
-        {'uuid':'u2','timestamp':2.0,'session_id':'s2','group': 'g2','action':'searchResultPage','checkin':np.nan,'page_id':'p2','n_results':9.0,'result_position':np.nan},
-        {'uuid':'u3','timestamp':2.0,'session_id':'s3','group': 'g3','action':'checkin',         'checkin':30,    'page_id':'p3','n_results':np.nan,'result_position':np.nan},
-        {'uuid':'u4','timestamp':2.0,'session_id':'s1','group': 'g1','action':'searchResultPage','checkin':np.nan,'page_id':'p1','n_results':5.0,'result_position':np.nan},
-        {'uuid':'u5','timestamp':2.0,'session_id':'s2','group': 'g2','action':'searchResultPage','checkin':np.nan,'page_id':'p2','n_results':9.0,'result_position':np.nan},
-        {'uuid':'u6','timestamp':2.0,'session_id':'s3','group': 'g3','action':'checkin',         'checkin':30,    'page_id':'p3','n_results':np.nan,'result_position':np.nan},
-        ])
+        {'uuid': 'u1', 'timestamp': 2.0, 'session_id': 's1', 'group': 'g1', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p1', 'n_results': 5.0, 'result_position': np.nan},
+        {'uuid': 'u2', 'timestamp': 2.0, 'session_id': 's2', 'group': 'g2', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p2', 'n_results': 9.0, 'result_position': np.nan},
+        {'uuid': 'u3', 'timestamp': 2.0, 'session_id': 's3', 'group': 'g3', 'action': 'checkin', 'checkin': 30, 'page_id': 'p3', 'n_results': np.nan, 'result_position': np.nan},
+        {'uuid': 'u4', 'timestamp': 2.0, 'session_id': 's1', 'group': 'g1', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p1', 'n_results': 5.0, 'result_position': np.nan},
+        {'uuid': 'u5', 'timestamp': 2.0, 'session_id': 's2', 'group': 'g2', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p2', 'n_results': 9.0, 'result_position': np.nan},
+        {'uuid': 'u6', 'timestamp': 2.0, 'session_id': 's3', 'group': 'g3', 'action': 'checkin', 'checkin': 30, 'page_id': 'p3', 'n_results': np.nan, 'result_position': np.nan},
+    ])
     assert_frame_equal(actual, expected)
 
     # Test single file option, csv
     path = 'tests/fixtures/data_sample/wiki_example/input/part1.csv'
     actual = load_df(path, file_type='csv', read_func='read_csv', read_kwargs={})
     expected = pd.DataFrame([
-        {'uuid':'u1','timestamp':2.0,'session_id':'s1','group': 'g1','action':'searchResultPage','checkin':np.nan,'page_id':'p1','n_results':5.0,'result_position':np.nan},
-        {'uuid':'u2','timestamp':2.0,'session_id':'s2','group': 'g2','action':'searchResultPage','checkin':np.nan,'page_id':'p2','n_results':9.0,'result_position':np.nan},
-        {'uuid':'u3','timestamp':2.0,'session_id':'s3','group': 'g3','action':'checkin','checkin':30,         'page_id':'p3','n_results':np.nan,'result_position':np.nan},
-        ])
+        {'uuid': 'u1', 'timestamp': 2.0, 'session_id': 's1', 'group': 'g1', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p1', 'n_results': 5.0, 'result_position': np.nan},
+        {'uuid': 'u2', 'timestamp': 2.0, 'session_id': 's2', 'group': 'g2', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p2', 'n_results': 9.0, 'result_position': np.nan},
+        {'uuid': 'u3', 'timestamp': 2.0, 'session_id': 's3', 'group': 'g3', 'action': 'checkin', 'checkin': 30, 'page_id': 'p3', 'n_results': np.nan, 'result_position': np.nan},
+    ])
     assert_frame_equal(actual, expected)
 
     # Test single file option, parquet
     path = 'tests/fixtures/data_sample/wiki_example/input_parquet/part1.parquet'
     actual = load_df(path, file_type='parquet', read_func='read_parquet', read_kwargs={})
     expected = pd.DataFrame([
-        {'uuid':'u1','timestamp':2.0,'session_id':'s1','group': 'g1','action':'searchResultPage','checkin':np.nan,'page_id':'p1','n_results':5.0,'result_position':np.nan},
-        {'uuid':'u2','timestamp':2.0,'session_id':'s2','group': 'g2','action':'searchResultPage','checkin':np.nan,'page_id':'p2','n_results':9.0,'result_position':np.nan},
-        {'uuid':'u3','timestamp':2.0,'session_id':'s3','group': 'g3','action':'checkin','checkin':30,         'page_id':'p3','n_results':np.nan,'result_position':np.nan},
-        ])
+        {'uuid': 'u1', 'timestamp': 2.0, 'session_id': 's1', 'group': 'g1', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p1', 'n_results': 5.0, 'result_position': np.nan},
+        {'uuid': 'u2', 'timestamp': 2.0, 'session_id': 's2', 'group': 'g2', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p2', 'n_results': 9.0, 'result_position': np.nan},
+        {'uuid': 'u3', 'timestamp': 2.0, 'session_id': 's3', 'group': 'g3', 'action': 'checkin', 'checkin': 30, 'page_id': 'p3', 'n_results': np.nan, 'result_position': np.nan},
+    ])
     assert_frame_equal(actual, expected)
 
     # Test single file option, excel
     path = 'tests/fixtures/data_sample/wiki_example/input_excel/parts.xlsx'
-    actual = load_df(path, file_type='xlsx', read_func='read_excel', read_kwargs={'engine':'openpyxl', 'sheet_name':0, 'header':1})
+    actual = load_df(path, file_type='xlsx', read_func='read_excel', read_kwargs={'engine': 'openpyxl', 'sheet_name': 0, 'header': 1})
     expected = pd.DataFrame([
-        {'uuid':'u1','timestamp':2,'session_id':'s1','group': 'g1','action':'searchResultPage','checkin':np.nan,'page_id':'p1','n_results':5.0,'result_position':np.nan},
-        {'uuid':'u2','timestamp':2,'session_id':'s2','group': 'g2','action':'searchResultPage','checkin':np.nan,'page_id':'p2','n_results':9.0,'result_position':np.nan},
-        {'uuid':'u3','timestamp':2,'session_id':'s3','group': 'g3','action':'checkin','checkin':30,         'page_id':'p3','n_results':np.nan,'result_position':np.nan},
-        ])
+        {'uuid': 'u1', 'timestamp': 2, 'session_id': 's1', 'group': 'g1', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p1', 'n_results': 5.0, 'result_position': np.nan},
+        {'uuid': 'u2', 'timestamp': 2, 'session_id': 's2', 'group': 'g2', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p2', 'n_results': 9.0, 'result_position': np.nan},
+        {'uuid': 'u3', 'timestamp': 2, 'session_id': 's3', 'group': 'g3', 'action': 'checkin', 'checkin': 30, 'page_id': 'p3', 'n_results': np.nan, 'result_position': np.nan},
+    ])
     assert_frame_equal(actual, expected)
 
 # TODO Add test 'test_load_multiple_csvs())', for completeness. functionality already tested above..
+
 
 def test_save_pandas_local():
     # Test save to csv
     path = 'tests/tmp/output.csv'
     df_in = pd.DataFrame([
-        {'uuid':'u1','timestamp':2.0,'session_id':'s1'},
-        {'uuid':'u2','timestamp':2.0,'session_id':'s2'},
-        {'uuid':'u3','timestamp':2.0,'session_id':'s3'},
-        ])
+        {'uuid': 'u1', 'timestamp': 2.0, 'session_id': 's1'},
+        {'uuid': 'u2', 'timestamp': 2.0, 'session_id': 's2'},
+        {'uuid': 'u3', 'timestamp': 2.0, 'session_id': 's3'},
+    ])
     save_pandas_local(df_in, path, save_method='to_csv', save_kwargs={})
     assert os.path.exists(path)
 

--- a/yaetos/daily_incremental_job.py
+++ b/yaetos/daily_incremental_job.py
@@ -22,7 +22,7 @@ class ETL_Daily_Incremental_Base(ETL_Base):
         first_day = self.jargs.merged_args['first_day']
         if not self.last_attempted_period:
             previous_output_max_timestamp = self.get_previous_output_max_timestamp()
-            self.last_attempted_period  = previous_output_max_timestamp.strftime("%Y-%m-%d") if previous_output_max_timestamp else first_day  # TODO: if get_output_max_timestamp()=None, means new build, so should delete instance in DBs.
+            self.last_attempted_period = previous_output_max_timestamp.strftime("%Y-%m-%d") if previous_output_max_timestamp else first_day  # TODO: if get_output_max_timestamp()=None, means new build, so should delete instance in DBs.
 
         periods = self.get_last_output_to_last_day(self.last_attempted_period, first_day)
         if len(periods) == 0:

--- a/yaetos/db_utils.py
+++ b/yaetos/db_utils.py
@@ -15,6 +15,7 @@ def cast_rec(rec, output_types):
         new_rec[field] = cast_value(rec[field], output_types[field], field)
     return new_rec
 
+
 def cast_value(value, required_type, field_name):
     # TODO: make it less ugly.. or avoid using pandas to not require this.
     try:
@@ -52,6 +53,7 @@ def cast_value(value, required_type, field_name):
         logger.error(u"cast_value issue: {}, {}, {}, {}, {}.".format(field_name, value, type(value), required_type, str(e)))
         return None
 
+
 def cast_col(df, output_types):
     for field in df.columns:
         if isinstance(output_types[field], type(db_types.FLOAT())):
@@ -62,22 +64,24 @@ def cast_col(df, output_types):
         #     df[field] = df[field].astype(int)  -> this "if" leads to pb in prod when they are none value + handled properly in prod with string inputs being converted to int.
     return df
 
+
 def get_spark_type(field, required_type):
     if isinstance(required_type, type(db_types.DATE())):
-        return spk_types.StructField(field,  spk_types.DateType(), True)
+        return spk_types.StructField(field, spk_types.DateType(), True)
     elif isinstance(required_type, type(db_types.DATETIME())):
-        return spk_types.StructField(field,  spk_types.TimestampType(), True)
+        return spk_types.StructField(field, spk_types.TimestampType(), True)
     elif isinstance(required_type, type(db_types.VARCHAR())):
-        return spk_types.StructField(field,  spk_types.StringType(), True)
+        return spk_types.StructField(field, spk_types.StringType(), True)
     elif isinstance(required_type, type(db_types.INT())):
-        return spk_types.StructField(field,  spk_types.LongType(), True)  # db type enforced earlier than spark ones, so spark types needs to be less restrictive than spark ones so needs to choose LongType instead of IntegerType
+        return spk_types.StructField(field, spk_types.LongType(), True)  # db type enforced earlier than spark ones, so spark types needs to be less restrictive than spark ones so needs to choose LongType instead of IntegerType
     elif isinstance(required_type, type(db_types.FLOAT())):
-        return spk_types.StructField(field,  spk_types.FloatType(), True)
+        return spk_types.StructField(field, spk_types.FloatType(), True)
     elif isinstance(required_type, type(db_types.BOOLEAN())):
-        return spk_types.StructField(field,  spk_types.BooleanType(), True)
+        return spk_types.StructField(field, spk_types.BooleanType(), True)
     else:
         raise Exception("Type not recognized, field={}, required_type={}".format(field, required_type))
     # BIGINT not usable here as not supported by Oracle.
+
 
 def get_spark_types(output_types):
     spark_types = []
@@ -89,17 +93,18 @@ def get_spark_types(output_types):
     logger.info('spark_schema: {}'.format(spark_schema))
     return spark_schema
 
+
 def pdf_to_sdf(df, output_types, sc, sc_sql):  # TODO: check suspicion that this leads to each node requiring loading all libs from this script.
     spark_schema = get_spark_types(output_types)
-    missing_columns = set(df.columns)-set(output_types.keys())
+    missing_columns = set(df.columns) - set(output_types.keys())
     if missing_columns:
         logger.warning('Some fields from source pandas df will not be pushed to spark df (because of absence in output_types), check if need to be added: {}.'.format(missing_columns))
 
     recs = df.to_dict(orient='records')
-    partitions = len(recs)/1000
+    partitions = len(recs) / 1000
     partitions = partitions if partitions >= 1 else None
     # Push to spark. For easier testing of downstream casting (i.e. outside of spark): tmp = [cast_rec(row, output_types) for row in recs]
     rdd = sc.parallelize(recs, numSlices=partitions) \
             .map(lambda row: cast_rec(row, output_types))
 
-    return sc_sql.createDataFrame(rdd, schema = spark_schema, verifySchema=True)
+    return sc_sql.createDataFrame(rdd, schema=spark_schema, verifySchema=True)

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -556,7 +556,7 @@ class DeployPySparkScriptOnAws(object):
     def list_data_pipeline(self, client):
         out = client.list_pipelines(marker='')
         pipelines = out['pipelineIdList']
-        while out['hasMoreResults'] == True:
+        while out['hasMoreResults'] is True:
             out = client.list_pipelines(marker=out['marker'])
             pipelines += out['pipelineIdList']
         return pipelines

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -33,7 +33,7 @@ class DeployPySparkScriptOnAws(object):
     """
     Programmatically deploy a local PySpark script on an AWS cluster
     """
-    SCRIPTS = 'yaetos/scripts/' # TODO: move to etl_utils.py
+    SCRIPTS = 'yaetos/scripts/'  # TODO: move to etl_utils.py
     TMP = 'tmp/files_to_ship/'
 
     def __init__(self, deploy_args, app_args):
@@ -48,15 +48,15 @@ class DeployPySparkScriptOnAws(object):
         self.app_args = app_args
         self.app_file = app_args['py_job']  # TODO: remove all refs to app_file to be consistent.
         self.aws_setup = aws_setup
-        self.ec2_key_name  = config.get(aws_setup, 'ec2_key_name')
-        self.s3_region     = config.get(aws_setup, 's3_region')
-        self.user          = config.get(aws_setup, 'user')
-        self.profile_name  = config.get(aws_setup, 'profile_name')
+        self.ec2_key_name = config.get(aws_setup, 'ec2_key_name')
+        self.s3_region = config.get(aws_setup, 's3_region')
+        self.user = config.get(aws_setup, 'user')
+        self.profile_name = config.get(aws_setup, 'profile_name')
         self.ec2_subnet_id = config.get(aws_setup, 'ec2_subnet_id')
         self.extra_security_gp = config.get(aws_setup, 'extra_security_gp')
         self.emr_core_instances = int(app_args.get('emr_core_instances', 1))  # TODO: make this update EMR_Scheduled mode too.
         self.deploy_args = deploy_args
-        self.ec2_instance_master = app_args.get('ec2_instance_master', 'm5.xlarge')  #'m5.12xlarge', # used m3.2xlarge (8 vCPU, 30 Gib RAM), and earlier m3.xlarge (4 vCPU, 15 Gib RAM)
+        self.ec2_instance_master = app_args.get('ec2_instance_master', 'm5.xlarge')  # 'm5.12xlarge', # used m3.2xlarge (8 vCPU, 30 Gib RAM), and earlier m3.xlarge (4 vCPU, 15 Gib RAM)
         self.ec2_instance_slaves = app_args.get('ec2_instance_slaves', 'm5.xlarge')
         # Paths
         self.s3_bucket_logs = config.get(aws_setup, 's3_bucket_logs')
@@ -64,8 +64,8 @@ class DeployPySparkScriptOnAws(object):
         self.pipeline_name = self.generate_pipeline_name(self.deploy_args['mode'], self.app_args['job_name'], self.user)  # format: some_job.some_user.20181204.153429
         self.job_log_path = self.get_job_log_path()  # format: yaetos/logs/some_job.some_user.20181204.153429
         self.job_log_path_with_bucket = '{}/{}'.format(self.s3_bucket_logs, self.job_log_path)   # format: bucket-tempo/yaetos/logs/some_job.some_user.20181204.153429
-        self.package_path  = self.job_log_path+'/code_package'   # format: yaetos/logs/some_job.some_user.20181204.153429/package
-        self.package_path_with_bucket  = self.job_log_path_with_bucket+'/code_package'   # format: bucket-tempo/yaetos/logs/some_job.some_user.20181204.153429/package
+        self.package_path = self.job_log_path + '/code_package'   # format: yaetos/logs/some_job.some_user.20181204.153429/package
+        self.package_path_with_bucket = self.job_log_path_with_bucket + '/code_package'   # format: bucket-tempo/yaetos/logs/some_job.some_user.20181204.153429/package
         self.session = boto3.Session(profile_name=self.profile_name)  # aka AWS IAM profile
 
         spark_version = self.deploy_args.get('spark_version', '2.4')
@@ -86,12 +86,11 @@ class DeployPySparkScriptOnAws(object):
             self.git_yml = None
             logger.info("Error saving yml file with git info, with error '{}'.".format(e))
 
-
     def run(self):
         if self.continue_post_git_check() is False:
             return False
 
-        if self.deploy_args['deploy']=='EMR':
+        if self.deploy_args['deploy'] == 'EMR':
             self.run_direct()
         elif self.deploy_args['deploy'] in ('EMR_Scheduled', 'EMR_DataPipeTest'):
             self.run_aws_data_pipeline()
@@ -108,7 +107,7 @@ class DeployPySparkScriptOnAws(object):
             print('Code not git controled: git check ignored')
             return True
 
-        git_yml = {key:value for key, value in self.git_yml.items() if key in ('is_dirty_yaetos', 'is_dirty_current', 'branch_current', 'branch_yaetos')}
+        git_yml = {key: value for key, value in self.git_yml.items() if key in ('is_dirty_yaetos', 'is_dirty_current', 'branch_current', 'branch_yaetos')}
         if self.git_yml['is_dirty_current'] or self.git_yml['is_dirty_yaetos']:
             print('Some changes to your git controled files are not committed to git: {}'.format(git_yml))
             answer = input('Are you sure you want to deploy it ? [y/n] ')
@@ -145,10 +144,10 @@ class DeployPySparkScriptOnAws(object):
         if new_cluster:
             print("Starting new cluster")
             self.start_spark_cluster(c, self.emr_version)
-            print("cluster name: %s, and id: %s"%(self.pipeline_name, self.cluster_id))
+            print("cluster name: %s, and id: %s" % (self.pipeline_name, self.cluster_id))
             self.step_run_setup_scripts(c)
         else:
-            print("Reusing existing cluster, name: %s, and id: %s"%(cluster['name'], cluster['id']))
+            print("Reusing existing cluster, name: %s, and id: %s" % (cluster['name'], cluster['id']))
             self.cluster_id = cluster['id']
             self.step_run_setup_scripts(c)
 
@@ -171,9 +170,9 @@ class DeployPySparkScriptOnAws(object):
 
     def get_active_clusters(self, c):
         response = c.list_clusters(
-            ClusterStates=['STARTING','BOOTSTRAPPING','RUNNING','WAITING'],
-            )
-        clusters = [(ii+1, item['Id'],item['Name']) for ii, item in enumerate(response['Clusters'])]
+            ClusterStates=['STARTING', 'BOOTSTRAPPING', 'RUNNING', 'WAITING'],
+        )
+        clusters = [(ii + 1, item['Id'], item['Name']) for ii, item in enumerate(response['Clusters'])]
         return clusters
 
     def choose_cluster(self, clusters, cluster_id=None):
@@ -187,20 +186,20 @@ class DeployPySparkScriptOnAws(object):
             return {'id': cluster_id,
                     'name': None}
 
-        clusters.append((len(clusters)+1, None, 'Create a new cluster'))
-        print('Clusters found for AWS account "%s":'%(self.aws_setup))
-        print('\n'.join(['[%s] %s'%(item[0], item[2]) for item in clusters]))
+        clusters.append((len(clusters) + 1, None, 'Create a new cluster'))
+        print('Clusters found for AWS account "%s":' % (self.aws_setup))
+        print('\n'.join(['[%s] %s' % (item[0], item[2]) for item in clusters]))
         answer = input('Your choice ? ')
-        return {'id':clusters[int(answer)-1][1],
-                'name':clusters[int(answer)-1][2]}
+        return {'id': clusters[int(answer) - 1][1],
+                'name': clusters[int(answer) - 1][2]}
 
     @staticmethod
     def generate_pipeline_name(mode, job_name, user):
-        mode_label = {'dev_EMR':'dev', 'prod_EMR':'prod'}[mode]
+        mode_label = {'dev_EMR': 'dev', 'prod_EMR': 'prod'}[mode]
         """Opposite of get_job_name()"""
         name = "yaetos__{mode_label}__{pname}__{time}".format(
             mode_label=mode_label,
-            pname=job_name.replace('.','_d_').replace('/','_s_'),
+            pname=job_name.replace('.', '_d_').replace('/', '_s_'),
             # user.replace('.','_'),
             time=datetime.now().strftime("%Y%m%dT%H%M%S"))
         print('Pipeline Name "{}":'.format(name))
@@ -212,7 +211,7 @@ class DeployPySparkScriptOnAws(object):
         return pipeline_name.split('__')[2].replace('_d_', '.').replace('_s_', '/') if '__' in pipeline_name else None
 
     def get_job_log_path(self):
-        if self.deploy_args.get('mode')=='prod_EMR':
+        if self.deploy_args.get('mode') == 'prod_EMR':
             return '{}/jobs_code/production'.format(self.metadata_folder)
         else:
             return '{}/jobs_code/{}'.format(self.metadata_folder, self.pipeline_name)
@@ -230,9 +229,9 @@ class DeployPySparkScriptOnAws(object):
             # If it was a 404 error, then the bucket does not exist.
             error_code = int(e.response['Error']['Code'])
             if error_code == 404:
-                terminate("Bucket for temporary files does not exist: "+self.s3_bucket_logs+' '+e.message)
-            terminate("Error while connecting to temporary Bucket: "+self.s3_bucket_logs+' '+e.message)
-        logger.info("S3 bucket for temporary files exists: "+self.s3_bucket_logs)
+                terminate("Bucket for temporary files does not exist: " + self.s3_bucket_logs + ' ' + e.message)
+            terminate("Error while connecting to temporary Bucket: " + self.s3_bucket_logs + ' ' + e.message)
+        logger.info("S3 bucket for temporary files exists: " + self.s3_bucket_logs)
 
     def tar_python_scripts(self):
         base = self.get_package_path()
@@ -251,23 +250,23 @@ class DeployPySparkScriptOnAws(object):
 
         # ./yaetos files
         # TODO: check a way to deploy the yaetos code locally for testing.
-        files = os.listdir(base+'yaetos/')
+        files = os.listdir(base + 'yaetos/')
         for f in files:
-            t_file.add(base+'yaetos/' + f, arcname='yaetos/' + f, filter=lambda obj: obj if obj.name.endswith('.py') else None)
+            t_file.add(base + 'yaetos/' + f, arcname='yaetos/' + f, filter=lambda obj: obj if obj.name.endswith('.py') else None)
 
         # ./libs files
         # TODO: get better way to walk down tree (reuse walk from below)
-        files = os.listdir(base+'yaetos/libs/')
+        files = os.listdir(base + 'yaetos/libs/')
         for f in files:
-            t_file.add(base+'yaetos/libs/' + f, arcname='yaetos/libs/' + f, filter=lambda obj: obj if obj.name.endswith('.py') else None)
+            t_file.add(base + 'yaetos/libs/' + f, arcname='yaetos/libs/' + f, filter=lambda obj: obj if obj.name.endswith('.py') else None)
 
-        files = os.listdir(base+'yaetos/libs/analysis_toolkit/')
+        files = os.listdir(base + 'yaetos/libs/analysis_toolkit/')
         for f in files:
-            t_file.add(base+'yaetos/libs/analysis_toolkit/' + f, arcname='yaetos/libs/analysis_toolkit/' + f, filter=lambda obj: obj if obj.name.endswith('.py') else None)
+            t_file.add(base + 'yaetos/libs/analysis_toolkit/' + f, arcname='yaetos/libs/analysis_toolkit/' + f, filter=lambda obj: obj if obj.name.endswith('.py') else None)
 
-        files = os.listdir(base+'yaetos/libs/python_db_connectors/')
+        files = os.listdir(base + 'yaetos/libs/python_db_connectors/')
         for f in files:
-            t_file.add(base+'yaetos/libs/python_db_connectors/' + f, arcname='yaetos/libs/python_db_connectors/' + f, filter=lambda obj: obj if obj.name.endswith('.py') else None)
+            t_file.add(base + 'yaetos/libs/python_db_connectors/' + f, arcname='yaetos/libs/python_db_connectors/' + f, filter=lambda obj: obj if obj.name.endswith('.py') else None)
 
         # ./jobs files and folders
         # TODO: extract code below in external function.
@@ -278,7 +277,7 @@ class DeployPySparkScriptOnAws(object):
                     path = os.path.join(dirpath, file)
                     dir_tar = dirpath[len(self.app_args['jobs_folder']):]
                     path_tar = os.path.join(eu.JOB_FOLDER, dir_tar, file)
-                    files.append((path,path_tar))
+                    files.append((path, path_tar))
         for f, f_arc in files:
             t_file.add(f, arcname=f_arc)
 
@@ -291,7 +290,7 @@ class DeployPySparkScriptOnAws(object):
     def move_bash_to_local_temp(self):
         base = self.get_package_path()
         for item in ['setup_master.sh', 'setup_master_alt.sh', 'setup_nodes.sh', 'setup_nodes_alt.sh', 'terminate_idle_cluster.sh']:
-            copyfile(base+self.SCRIPTS+item, self.TMP+item)
+            copyfile(base + self.SCRIPTS + item, self.TMP + item)
         logger.info("Added all EMR setup files to {}".format(self.TMP))
 
     def get_package_path(self):
@@ -300,12 +299,12 @@ class DeployPySparkScriptOnAws(object):
         """
         if self.app_args['code_source'] == 'lib':
             bases = site.getsitepackages()
-            if len(bases)>1:
+            if len(bases) > 1:
                 logger.info("There is more than one source of code to ship to EMR '{}'. Will continue with the first one.".format(bases))
             base = bases[0] + '/'
         elif self.app_args['code_source'] == 'repo':
             base = eu.LOCAL_FRAMEWORK_FOLDER
-        logger.info("Source of yaetos code to be shipped: {}".format(base+'yaetos/'))
+        logger.info("Source of yaetos code to be shipped: {}".format(base + 'yaetos/'))
         return base
 
     def upload_temp_files(self, s3):
@@ -317,13 +316,13 @@ class DeployPySparkScriptOnAws(object):
 
         # Looping through all 4 steps below doesn't work (Fails silently) so done 1 by 1.
         s3.Object(self.s3_bucket_logs, self.package_path + '/setup_master.sh')\
-          .put(Body=open(self.TMP+setup_master, 'rb'), ContentType='text/x-sh')
+          .put(Body=open(self.TMP + setup_master, 'rb'), ContentType='text/x-sh')
         s3.Object(self.s3_bucket_logs, self.package_path + '/setup_nodes.sh')\
-          .put(Body=open(self.TMP+setup_nodes, 'rb'), ContentType='text/x-sh')
+          .put(Body=open(self.TMP + setup_nodes, 'rb'), ContentType='text/x-sh')
         s3.Object(self.s3_bucket_logs, self.package_path + '/terminate_idle_cluster.sh')\
-          .put(Body=open(self.TMP+'terminate_idle_cluster.sh', 'rb'), ContentType='text/x-sh')
+          .put(Body=open(self.TMP + 'terminate_idle_cluster.sh', 'rb'), ContentType='text/x-sh')
         s3.Object(self.s3_bucket_logs, self.package_path + '/scripts.tar.gz')\
-          .put(Body=open(self.TMP+'scripts.tar.gz', 'rb'), ContentType='application/x-tar')
+          .put(Body=open(self.TMP + 'scripts.tar.gz', 'rb'), ContentType='application/x-tar')
         logger.info("Uploaded job files (scripts.tar.gz, {}, {}, terminate_idle_cluster.sh) to bucket path '{}/{}'".format(setup_master, setup_nodes, self.s3_bucket_logs, self.package_path))
         return True
 
@@ -349,14 +348,14 @@ class DeployPySparkScriptOnAws(object):
             'InstanceRole': 'MASTER',
             'InstanceType': self.ec2_instance_master,
             'InstanceCount': 1,
-            }]
+        }]
         if self.emr_core_instances != 0:
             instance_groups += [{
                 'Name': 'EmrCore',
                 'InstanceRole': 'CORE',
                 'InstanceType': self.ec2_instance_slaves,
                 'InstanceCount': self.emr_core_instances,
-                }]
+            }]
 
         response = c.run_job_flow(
             Name=self.pipeline_name,
@@ -371,11 +370,11 @@ class DeployPySparkScriptOnAws(object):
             },
             Applications=[{'Name': 'Hadoop'}, {'Name': 'Spark'}],
             Configurations=[
-                { # Section to force python3 since emr-5.x uses python2 by default.
-                "Classification": "spark-env",
-                "Configurations": [{
-                    "Classification": "export",
-                    "Properties": {"PYSPARK_PYTHON": "/usr/bin/python3"}
+                {  # Section to force python3 since emr-5.x uses python2 by default.
+                    "Classification": "spark-env",
+                    "Configurations": [{
+                        "Classification": "export",
+                        "Properties": {"PYSPARK_PYTHON": "/usr/bin/python3"}
                     }]
                 },
                 # { # Section to add jars (redshift...), not used for now, since passed in spark-submit args.
@@ -391,9 +390,9 @@ class DeployPySparkScriptOnAws(object):
                 'ScriptBootstrapAction': {
                     'Path': 's3n://{}/setup_nodes.sh'.format(self.package_path_with_bucket),
                     'Args': []
-                    }
-                }],
-            )
+                }
+            }],
+        )
         # Process response to determine if Spark cluster was started, and if so, the JobFlowId of the cluster
         response_code = response['ResponseMetadata']['HTTPStatusCode']
         if response['ResponseMetadata']['HTTPStatusCode'] == 200:
@@ -434,10 +433,10 @@ class DeployPySparkScriptOnAws(object):
                     'Args': [
                         "s3://{}/setup_master.sh".format(self.package_path_with_bucket),
                         "s3://{}".format(self.package_path_with_bucket),
-                        ]
-                    }
-                }]
-            )
+                    ]
+                }
+            }]
+        )
         logger.info("Added step")
         time.sleep(1)  # Prevent ThrottlingException
 
@@ -456,9 +455,9 @@ class DeployPySparkScriptOnAws(object):
                 'HadoopJarStep': {
                     'Jar': 'command-runner.jar',
                     'Args': cmd_runner_args
-                    }
-                }]
-            )
+                }
+            }]
+        )
         logger.info("Added step 'spark-submit' with command line '{}'".format(cmd_runner_args))
         time.sleep(1)  # Prevent ThrottlingException
 
@@ -475,23 +474,23 @@ class DeployPySparkScriptOnAws(object):
             "--py-files={}scripts.zip".format(eu.CLUSTER_APP_FOLDER),
             "--packages={}".format(package_str),
             "--jars={}".format(eu.JARS),
-            ]
+        ]
         med = ["--driver-memory={}".format(app_args['driver-memory'])] if app_args.get('driver-memory') else []
         cod = ["--driver-cores={}".format(app_args['driver-cores'])] if app_args.get('driver-cores') else []
         mee = ["--executor-memory={}".format(app_args['executor-memory'])] if app_args.get('executor-memory') else []
         coe = ["--executor-cores={}".format(app_args['executor-cores'])] if app_args.get('executor-cores') else []
 
         spark_app_args = [
-            eu.CLUSTER_APP_FOLDER+launcher_file,
+            eu.CLUSTER_APP_FOLDER + launcher_file,
             "--mode={}".format(emr_mode),
             "--deploy=none",
             "--storage=s3",
             "--rerun_criteria={}".format(app_args.get('rerun_criteria')),
-            ]
-        jop = ['--job_param_file={}'.format(eu.CLUSTER_APP_FOLDER+eu.JOBS_METADATA_FILE)] if app_args.get('job_param_file') else []
+        ]
+        jop = ['--job_param_file={}'.format(eu.CLUSTER_APP_FOLDER + eu.JOBS_METADATA_FILE)] if app_args.get('job_param_file') else []
         dep = ["--dependencies"] if app_args.get('dependencies') else []
         box = ["--chain_dependencies"] if app_args.get('chain_dependencies') else []
-        sql = [] # ["--sql_file={}".format(eu.CLUSTER_APP_FOLDER+app_args['sql_file'])] if app_args.get('sql_file') else [] # not needed when sql job is run from jobs/generic/launcher.py. TODO: make it work when launching from jobs/generic/sql_job.py
+        sql = []  # ["--sql_file={}".format(eu.CLUSTER_APP_FOLDER+app_args['sql_file'])] if app_args.get('sql_file') else [] # not needed when sql job is run from jobs/generic/launcher.py. TODO: make it work when launching from jobs/generic/sql_job.py
         nam = ["--job_name={}".format(app_args['job_name'])] if app_args.get('job_name') else []
 
         return spark_submit_args + med + cod + mee + coe + spark_app_args + jop + dep + box + sql + nam
@@ -523,18 +522,18 @@ class DeployPySparkScriptOnAws(object):
         base = self.get_package_path()
 
         if emr_core_instances != 0:
-            definition_file = base+'yaetos/definition.json'  # see syntax in datapipeline-dg.pdf p285 # to add in there: /*"AdditionalMasterSecurityGroups": "#{}",  /* To add later to match EMR mode */
+            definition_file = base + 'yaetos/definition.json'  # see syntax in datapipeline-dg.pdf p285 # to add in there: /*"AdditionalMasterSecurityGroups": "#{}",  /* To add later to match EMR mode */
         else:
-            definition_file = base+'yaetos/definition_standalone_cluster.json'
+            definition_file = base + 'yaetos/definition_standalone_cluster.json'
             # TODO: have 1 json for both to avoid having to track duplication.
 
-        definition = json.load(open(definition_file, 'r')) # Note: Data Pipeline doesn't support emr-6.0.0 yet.
+        definition = json.load(open(definition_file, 'r'))  # Note: Data Pipeline doesn't support emr-6.0.0 yet.
 
         pipelineObjects = trans.definition_to_api_objects(definition)
         parameterObjects = trans.definition_to_api_parameters(definition)
         parameterValues = trans.definition_to_parameter_values(definition)
         parameterValues = self.update_params(parameterValues)
-        logger.info('Filled pipeline with data from '+definition_file)
+        logger.info('Filled pipeline with data from ' + definition_file)
 
         response = client.put_pipeline_definition(
             pipelineId=pipe_id,
@@ -542,7 +541,7 @@ class DeployPySparkScriptOnAws(object):
             parameterObjects=parameterObjects,
             parameterValues=parameterValues
         )
-        logger.info('put_pipeline_definition response: '+str(response))
+        logger.info('put_pipeline_definition response: ' + str(response))
         return parameterValues
 
     def activate_data_pipeline(self, client, pipe_id, parameterValues):
@@ -551,7 +550,7 @@ class DeployPySparkScriptOnAws(object):
             parameterValues=parameterValues,  # optional. If set, need to specify all params as per json.
             # startTimestamp=datetime(2018, 12, 1)  # optional
         )
-        logger.info('activate_pipeline response: '+str(response))
+        logger.info('activate_pipeline response: ' + str(response))
         logger.info('Activated pipeline ' + pipe_id)
 
     def list_data_pipeline(self, client):
@@ -579,7 +578,7 @@ class DeployPySparkScriptOnAws(object):
             myStartDateTime = self.deploy_args['start_date'].strftime('%Y-%m-%dT%H:%M:%S')
         elif self.deploy_args['start_date'] and isinstance(self.deploy_args['start_date'], str):
             myStartDateTime = self.deploy_args['start_date'].format(today=datetime.today().strftime('%Y-%m-%d'))
-        else :
+        else:
             myStartDateTime = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')
         bootstrap = 's3://{}/setup_nodes.sh'.format(self.package_path_with_bucket)
 
@@ -609,19 +608,18 @@ class DeployPySparkScriptOnAws(object):
             elif 'myCoreInstanceType' in item.values():
                 parameterValues[ii] = {'id': u'myCoreInstanceType', 'stringValue': self.ec2_instance_slaves}
 
-
         # Change steps to include proper path
-        setup_command =  's3://elasticmapreduce/libs/script-runner/script-runner.jar,s3://{s3_tmp_path}/setup_master.sh,s3://{s3_tmp_path}'.format(s3_tmp_path=self.package_path_with_bucket) # s3://elasticmapreduce/libs/script-runner/script-runner.jar,s3://bucket-tempo/ex1_frameworked_job.arthur_user1.20181129.231423/setup_master.sh,s3://bucket-tempo/ex1_frameworked_job.arthur_user1.20181129.231423/
+        setup_command = 's3://elasticmapreduce/libs/script-runner/script-runner.jar,s3://{s3_tmp_path}/setup_master.sh,s3://{s3_tmp_path}'.format(s3_tmp_path=self.package_path_with_bucket)  # s3://elasticmapreduce/libs/script-runner/script-runner.jar,s3://bucket-tempo/ex1_frameworked_job.arthur_user1.20181129.231423/setup_master.sh,s3://bucket-tempo/ex1_frameworked_job.arthur_user1.20181129.231423/
         spark_submit_command = 'command-runner.jar,' + ','.join([item.replace(',', '\\\,') for item in self.get_spark_submit_args(self.app_file, self.app_args)])   # command-runner.jar,spark-submit,--py-files,/home/hadoop/app/scripts.zip,--packages=com.amazonaws:aws-java-sdk-pom:1.11.760\\\\,org.apache.hadoop:hadoop-aws:2.7.0,/home/hadoop/app/jobs/examples/ex1_frameworked_job.py,--storage=s3  # instructions about \\\ part: https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-emractivity.html
 
-        commands  = [setup_command, spark_submit_command]
+        commands = [setup_command, spark_submit_command]
         mm = 0
         for ii, item in enumerate(parameterValues):
             if 'myEmrStep' in item.values() and mm < 2:  # TODO: make more generic and cleaner
                 parameterValues[ii] = {'id': u'myEmrStep', 'stringValue': commands[mm]}
                 mm += 1
 
-        logger.info('parameterValues after changes: '+str(parameterValues))
+        logger.info('parameterValues after changes: ' + str(parameterValues))
         return parameterValues
 
     def push_secrets(self, creds_or_file):
@@ -636,14 +634,14 @@ class DeployPySparkScriptOnAws(object):
                 Name=eu.AWS_SECRET_ID,
                 SecretString=content,
             )
-            logger.debug('create_secret response: '+str(response))
+            logger.debug('create_secret response: ' + str(response))
             logger.info('Created aws secret, from {}, under secret_id:{}'.format(creds_or_file, eu.AWS_SECRET_ID))
         except client.exceptions.ResourceExistsException:
             response = client.put_secret_value(
                 SecretId=eu.AWS_SECRET_ID,
                 SecretString=content,
             )
-            logger.debug('put_secret_value response: '+str(response))
+            logger.debug('put_secret_value response: ' + str(response))
             logger.info('Updated aws secret, from {}, under secret_id:{}'.format(creds_or_file, eu.AWS_SECRET_ID))
 
     def delete_secrets(self):
@@ -655,19 +653,19 @@ class DeployPySparkScriptOnAws(object):
             # RecoveryWindowInDays=123,
             ForceDeleteWithoutRecovery=True
         )
-        logger.debug('delete_secret response: '+str(response))
-        logger.info('Deleted aws secret, secret_id:'+eu.AWS_SECRET_ID)
+        logger.debug('delete_secret response: ' + str(response))
+        logger.info('Deleted aws secret, secret_id:' + eu.AWS_SECRET_ID)
         print('delete_secret response: {}'.format(response))
 
 
 def deploy_all_scheduled():
-    ### Experimental ! Has lead to errors like: /usr/bin/python3: can't open file '/home/hadoop/app/jobs/frontroom/hotel_staff_usage_job.py': [Errno 2] No such file or directory
-    ### pb I don't get when deploying normally, from job files.
-    ### TODO: also need to remove "dependency" run for the ones with no dependencies.
+    # Experimental ! Has lead to errors like: /usr/bin/python3: can't open file '/home/hadoop/app/jobs/frontroom/hotel_staff_usage_job.py': [Errno 2] No such file or directory
+    # pb I don't get when deploying normally, from job files.
+    # TODO: also need to remove "dependency" run for the ones with no dependencies.
     def get_yml(args):
         meta_file = args.get('job_param_file', 'repo')
         if meta_file == 'repo':
-            meta_file = eu.CLUSTER_APP_FOLDER+eu.JOBS_METADATA_FILE if args['storage']=='s3' else eu.JOBS_METADATA_LOCAL_FILE
+            meta_file = eu.CLUSTER_APP_FOLDER + eu.JOBS_METADATA_FILE if args['storage'] == 's3' else eu.JOBS_METADATA_LOCAL_FILE
         yml = eu.Job_Args_Parser.load_meta(meta_file)
         logger.info('Loaded job param file: ' + meta_file)
         return yml
@@ -675,31 +673,31 @@ def deploy_all_scheduled():
     def get_bool(prompt):
         while True:
             try:
-               return {"":True, "y":True,"n":False}[input(prompt).lower()]
+                return {"": True, "y": True, "n": False}[input(prompt).lower()]
             except KeyError:
-               print("Invalid input please enter y or n!")
+                print("Invalid input please enter y or n!")
 
     def validate_job(job):
         return get_bool('Want to schedule "{}" [Y/n]? '.format(job))
 
     # TODO: reuse etl_utils.py Commandliner/set_commandline_args() to have cleaner interface and proper default values.
     deploy_args = {'leave_on': False,
-                   'aws_config_file':eu.AWS_CONFIG_FILE, # TODO: make set-able
-                   'aws_setup':'dev'}
-    app_args = {'deploy':'EMR_Scheduled',
-                'job_param_file': 'conf/jobs_metadata.yml', # TODO: make set-able. Set to external repo for testing.
+                   'aws_config_file': eu.AWS_CONFIG_FILE,  # TODO: make set-able
+                   'aws_setup': 'dev'}
+    app_args = {'deploy': 'EMR_Scheduled',
+                'job_param_file': 'conf/jobs_metadata.yml',  # TODO: make set-able. Set to external repo for testing.
                 'chain_dependencies': False,
                 'dependencies': True,
                 'storage': 'local',
                 'jobs_folder': eu.JOB_FOLDER,  # TODO: make set-able
-                'connection_file': eu.CONNECTION_FILE, # TODO: make set-able
+                'connection_file': eu.CONNECTION_FILE,  # TODO: make set-able
                 }
 
     yml = get_yml(app_args)
     pipelines = yml.keys()
     for pipeline in pipelines:
         jargs = eu.Job_Args_Parser(app_args)
-        jargs.set_job_params(job_name=pipeline) # broken TODO: fix.
+        jargs.set_job_params(job_name=pipeline)  # broken TODO: fix.
         if not jargs.frequency:
             continue
 
@@ -720,16 +718,17 @@ def terminate(error_message=None):
     logger.critical('The script is now terminating')
     exit()
 
+
 def deploy_standalone(job_args_update={}):
     # TODO: refactor below to use 'deploy' arg to trigger all deploy features, instead of new 'deploy_option' set below.
     job_args = {
         # --- regular job params ---
         'job_param_file': None,
-        'mode':'dev_EMR',
-        'output': {'path':'n_a', 'type':'csv'},
+        'mode': 'dev_EMR',
+        'output': {'path': 'n_a', 'type': 'csv'},
         'job_name': 'n_a',
         # --- params specific to running this file directly, can be overriden by command line ---
-        'deploy_option':'deploy_code_only',
+        'deploy_option': 'deploy_code_only',
     }
     job_args.update(job_args_update)
 
@@ -737,9 +736,9 @@ def deploy_standalone(job_args_update={}):
     cmd_args = eu.Commandliner.set_commandline_args(parser)
     jargs = eu.Job_Args_Parser(defaults_args=defaults_args, yml_args=None, job_args=job_args, cmd_args=cmd_args, loaded_inputs={})
     deploy_args = jargs.get_deploy_args()
-    app_args=jargs.get_app_args()
+    app_args = jargs.get_app_args()
 
-    if jargs.deploy_option == 'deploy_job': # can be used to push random code to cluster
+    if jargs.deploy_option == 'deploy_job':  # can be used to push random code to cluster
         # TODO: fails to create a new cluster but works to add a step to an existing cluster.
         DeployPySparkScriptOnAws(deploy_args, app_args).run()
 
@@ -754,7 +753,7 @@ def deploy_standalone(job_args_update={}):
         print('#--- pipelines: ', pipelines)
 
     elif jargs.deploy_option == 'deploy_all_jobs':
-        deploy_all_scheduled() # TODO: needs more testing.
+        deploy_all_scheduled()  # TODO: needs more testing.
 
     elif jargs.deploy_option == 'package_code_locally_only':  # only for debuging
         deployer = DeployPySparkScriptOnAws(deploy_args, app_args)  # TODO: should remove need for some of these inputs as they are not required by tar_python_scripts()

--- a/yaetos/env_dispatchers.py
+++ b/yaetos/env_dispatchers.py
@@ -4,7 +4,7 @@ Set of operations that require dispatching between local and cloud environment.
 import boto3
 import os
 from io import StringIO
-#from sklearn.externals import joblib  # TODO: re-enable after fixing lib versions.
+# from sklearn.externals import joblib  # TODO: re-enable after fixing lib versions.
 from configparser import ConfigParser
 from yaetos.pandas_utils import load_df, save_pandas_local
 from yaetos.logger import setup_logging
@@ -26,8 +26,8 @@ class FS_Ops_Dispatcher():
         fname_parts = [item for item in fname_parts if item != '']
         return (bucket_name, bucket_fname, fname_parts)
 
-
     # --- save_metadata set of functions ----
+
     def save_metadata(self, fname, content):
         self.save_metadata_cluster(fname, content) if self.is_s3_path(fname) else self.save_metadata_local(fname, content)
 
@@ -48,8 +48,8 @@ class FS_Ops_Dispatcher():
         s3c.put_object(Bucket=bucket_name, Key=bucket_fname, Body=fake_handle.read())
         logger.info("Created file S3: {}".format(fname))
 
-    ## --- save_file set of functions ----
-    ## Disabled until joblib enabled. Will be useful for ML use case.
+    # --- save_file set of functions ----
+    # Disabled until joblib enabled. Will be useful for ML use case.
     # def save_file(self, fname, content):
     #     self.save_file_cluster(fname, content) if self.is_s3_path(fname) else self.save_file_local(fname, content)
     #
@@ -133,8 +133,8 @@ class FS_Ops_Dispatcher():
     def dir_exist_cluster(path):
         raise NotImplementedError
 
-
     # --- load_pandas set of functions ----
+
     def load_pandas(self, fname, file_type, read_func, read_kwargs):
         return self.load_pandas_cluster(fname, file_type, read_func, read_kwargs) if self.is_s3_path(fname) else self.load_pandas_local(fname, file_type, read_func, read_kwargs)
 
@@ -147,7 +147,7 @@ class FS_Ops_Dispatcher():
         from cloudpathlib import CloudPath
 
         bucket_name, bucket_fname, fname_parts = self.split_s3_path(fname)
-        local_path = 'tmp/s3_copy_'+fname_parts[-1]
+        local_path = 'tmp/s3_copy_' + fname_parts[-1]
         cp = CloudPath(fname)  # TODO: add way to load it with specific profile_name or client, as in "s3c = boto3.Session(profile_name='default').client('s3')"
         logger.info("Copying files from S3 '{}' to local '{}'. May take some time.".format(fname, local_path))
         local_pathlib = cp.download_to(local_path)
@@ -156,8 +156,8 @@ class FS_Ops_Dispatcher():
         df = load_df(local_path, file_type, read_func, read_kwargs)
         return df
 
-
     # --- save_pandas set of functions ----
+
     def save_pandas(self, df, fname, save_method, save_kwargs):
         return self.save_pandas_cluster(df, fname, save_method, save_kwargs) if self.is_s3_path(fname) else self.save_pandas_local(df, fname, save_method, save_kwargs)
 
@@ -179,7 +179,7 @@ class FS_Ops_Dispatcher():
 
 class Cred_Ops_Dispatcher():
     def retrieve_secrets(self, storage, aws_creds='/yaetos/connections', local_creds='conf/connections.cfg'):
-        creds = self.retrieve_secrets_cluster(aws_creds) if storage=='s3' else self.retrieve_secrets_local(local_creds)
+        creds = self.retrieve_secrets_cluster(aws_creds) if storage == 's3' else self.retrieve_secrets_local(local_creds)
         return creds
 
     @staticmethod
@@ -187,8 +187,8 @@ class Cred_Ops_Dispatcher():
         client = boto3.Session(profile_name='default').client('secretsmanager')
 
         response = client.get_secret_value(SecretId=creds)
-        logger.info('Read aws secret, secret_id:'+creds)
-        logger.debug('get_secret_value response: '+str(response))
+        logger.info('Read aws secret, secret_id:' + creds)
+        logger.debug('get_secret_value response: ' + str(response))
         content = response['SecretString']
 
         fake_handle = StringIO(content)

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -20,8 +20,6 @@ from time import time
 import networkx as nx
 import random
 import pandas as pd
-import os
-import sys
 import numpy as np
 import gc
 from pprint import pformat

--- a/yaetos/excel_utils.py
+++ b/yaetos/excel_utils.py
@@ -10,6 +10,7 @@ def load_excel(jargs, input_name, output_types, sc, sc_sql, **xls_args):
     sdf = pdf_to_sdf(pdf, output_types, sc, sc_sql)
     return sdf
 
+
 def load_excel_pandas(jargs, input_name, **xls_args):
 
     path = jargs.inputs[input_name]['path']

--- a/yaetos/git_utils.py
+++ b/yaetos/git_utils.py
@@ -33,14 +33,14 @@ class Git_Config_Manager():
         diffs_yaetos = subprocess.check_output(['git', 'diff', 'HEAD'], cwd=local_app_folder).strip().decode('ascii')
         is_dirty_yaetos = True if diffs_yaetos else False
 
-        config = {'branch_current':branch,
-                  'last_commit_current':last_commit,
-                  'diffs_current':diffs,
-                  'is_dirty_current':is_dirty,
-                  'branch_yaetos':branch_yaetos,
-                  'last_commit_yaetos':last_commit_yaetos,
-                  'diffs_yaetos':diffs_yaetos,
-                  'is_dirty_yaetos':is_dirty_yaetos
+        config = {'branch_current': branch,
+                  'last_commit_current': last_commit,
+                  'diffs_current': diffs,
+                  'is_dirty_current': is_dirty,
+                  'branch_yaetos': branch_yaetos,
+                  'last_commit_yaetos': last_commit_yaetos,
+                  'diffs_yaetos': diffs_yaetos,
+                  'is_dirty_yaetos': is_dirty_yaetos
                   }
         return config
 
@@ -59,7 +59,7 @@ class Git_Config_Manager():
 
     def get_config_from_file(self, cluster_app_folder):
         """Meant to work in EMR"""
-        fname = cluster_app_folder+self.FNAME
+        fname = cluster_app_folder + self.FNAME
         if os.path.isfile(fname):
             with open(fname, 'r') as stream:
                 yml = yaml.load(stream, Loader=yaml.FullLoader)

--- a/yaetos/kafka_utils.py
+++ b/yaetos/kafka_utils.py
@@ -28,7 +28,7 @@ class KafkaProducer(object):
         schema = response.json()
         logger.info("Producer schema uri to pull schema data: {}".format(schema_uri))
         logger.info("Producer schema data pulled from schema service: {}.".format(schema))
-        schema["$schema"] = self.__SCHEMA_URI # DIRTY FIX
+        schema["$schema"] = self.__SCHEMA_URI  # DIRTY FIX
         self.__schema = schema
 
     def build_message(self, **rec):
@@ -45,7 +45,7 @@ class KafkaProducer(object):
         # Actual send part
         if to_send:
             msg_in = bytes(bytearray(json.dumps(message), "UTF-8"))
-            msg_out = self.__producer.send( self.__TOPIC, msg_in )
+            msg_out = self.__producer.send(self.__TOPIC, msg_in)
 
             # Post send
             msg_out.get(timeout=self.__send_timeout)

--- a/yaetos/libs/analysis_toolkit/api_helper.py
+++ b/yaetos/libs/analysis_toolkit/api_helper.py
@@ -1,6 +1,7 @@
 from ConfigParser import ConfigParser
 import os
 
+
 def get_user_pass(cred_profile, fpath=None):
     config = ConfigParser()
     if not fpath:

--- a/yaetos/libs/analysis_toolkit/query_helper.py
+++ b/yaetos/libs/analysis_toolkit/query_helper.py
@@ -71,7 +71,7 @@ def diff_dfs(df1, df2):
         hash1 = hashlib.sha256(pd.util.hash_pandas_object(df1, index=True).values).hexdigest()
         hash2 = hashlib.sha256(pd.util.hash_pandas_object(df2, index=True).values).hexdigest()
         is_identical = hash1 == hash2
-    except:
+    except Exception as err:
         print("Diff computation failed so assuming files are not similar.")
         return False
 

--- a/yaetos/libs/analysis_toolkit/query_helper.py
+++ b/yaetos/libs/analysis_toolkit/query_helper.py
@@ -188,13 +188,13 @@ def compare_dfs(df1, pks1, compare1, df2, pks2, compare2, strip=True, filter_del
         try:
             df_joined['_delta_' + item1] = df_joined.apply(lambda row: (row[item1] if not pd.isna(row[item1]) else 0.0) - (row[item2] if not pd.isna(row[item2]) else 0.0), axis=1)  # need to deal with case where df1 and df2 have same col name and merge adds suffix _1 and _2
             df_joined['_delta_' + item1 + '_%'] = df_joined.apply(check_delta, axis=1)
-            df_joined['_no_deltas'] = df_joined.apply(lambda row: row['_no_deltas'] == True and row['_delta_' + item1 + '_%'] < threshold, axis=1)
+            df_joined['_no_deltas'] = df_joined.apply(lambda row: row['_no_deltas'] is True and row['_delta_' + item1 + '_%'] < threshold, axis=1)
         except Exception as err:
             raise Exception("Failed item={}, error: \n{}".format(item1, err))
 
     np.seterr(divide='raise')
     if filter_deltas:
-        df_joined = df_joined[df_joined.apply(lambda row: row['_no_deltas'] == False, axis=1)].reset_index()
+        df_joined = df_joined[df_joined.apply(lambda row: row['_no_deltas'] is False, axis=1)].reset_index()
     df_joined.sort_values(by=['_merge'] + pks1, inplace=True)
     return df_joined
 

--- a/yaetos/libs/analysis_toolkit/query_helper.py
+++ b/yaetos/libs/analysis_toolkit/query_helper.py
@@ -22,11 +22,12 @@ def query_and_cache(query_str, name, folder, to_csv_args={}, dbargs={}, db_type=
         print("Loaded from file: ", fname_pykl)
     return df
 
+
 def process_and_cache(name, folder, func, to_csv_args={}, force_rerun=False, show=False, **func_args):
     # code here mostly duplicated from query_and_cache, TODO: get better way
     (name, fname_base, fname_csv, fname_pykl, fname_sql) = filename_expansion(name, folder)
     if not os.path.isfile(fname_pykl) or force_rerun:
-        print("Running output: ", folder+name, ", funct: ", func) #, 'with args', func_args
+        print("Running output: ", folder + name, ", funct: ", func)  # , 'with args', func_args
         start_time = time()
         df = func(**func_args)
         end_time = time()
@@ -39,6 +40,7 @@ def process_and_cache(name, folder, func, to_csv_args={}, force_rerun=False, sho
         print("Loaded from file: ", fname_pykl)
     return df
 
+
 def drop_if_needed(df, name, folder, to_csv_args, db_type='n/a', elapsed='n/a', query_str='n/a', force_rerun=True):
     (name, fname_base, fname_csv, fname_pykl, fname_sql) = filename_expansion(name, folder)
     prev_file_exist = os.path.isfile(fname_pykl)
@@ -47,7 +49,7 @@ def drop_if_needed(df, name, folder, to_csv_args, db_type='n/a', elapsed='n/a', 
         is_same = diff_dfs(df_pre, df)
         if is_same:
             print("Output is the same as the previous one (from '{}') so not re-dropping it.".format(fname_pykl))
-            #TODO: should still drop the sql file in case it has changed.
+            # TODO: should still drop the sql file in case it has changed.
         else:
             option = ask_user(is_same, fname_pykl)
             if option == 'overwrite':
@@ -61,6 +63,7 @@ def drop_if_needed(df, name, folder, to_csv_args, db_type='n/a', elapsed='n/a', 
                 print("Didn't drop the files.")
     else:
         drop_files(df, fname_pykl, fname_csv, fname_sql, name, db_type, elapsed, query_str, to_csv_args)
+
 
 def diff_dfs(df1, df2):
     print('Looking into diffs between previous and new dataset.')
@@ -86,6 +89,7 @@ def diff_dfs(df1, df2):
     print('columns are the same.')
     return False
 
+
 def filename_expansion(name, folder):
     if name.endswith('.csv'):
         name = name[:-4]
@@ -95,14 +99,16 @@ def filename_expansion(name, folder):
     fname_sql = fname_base + ".sql"
     return name, fname_base, fname_csv, fname_pykl, fname_sql
 
+
 def drop_files(df, fname_pykl, fname_csv, fname_sql, name, db_type, elapsed, query_str, to_csv_args={}):
     df.to_pickle(fname_pykl)
-    kwargs = {'sep':';', 'encoding':'utf8', 'decimal':'.'}
+    kwargs = {'sep': ';', 'encoding': 'utf8', 'decimal': '.'}
     kwargs.update(to_csv_args)
     df.to_csv(fname_csv, **kwargs)  # Ex to_csv_args: index=False, decimal=',' (for EU), encoding='utf8', or encoding='cp1252'
-    content = "-- name: %s\n-- db_creds (#db_type#): %s\n-- time (s): %s\n-- query: \n%s\n-- end"%(name, db_type, elapsed, query_str)
+    content = "-- name: %s\n-- db_creds (#db_type#): %s\n-- time (s): %s\n-- query: \n%s\n-- end" % (name, db_type, elapsed, query_str)
     write_file(fname_sql, content)
     print("Wrote table to files: ", fname_pykl, fname_csv, fname_sql)
+
 
 def ask_user(is_identical, fname_pykl):
     print("Output is different from the previous one ('{}'), do you want to:".format(fname_pykl))
@@ -112,6 +118,7 @@ def ask_user(is_identical, fname_pykl):
     answer = input('Your choice ? ')
     options = {1: 'overwrite', 2: 'new_name', 3: 'ignore'}
     return options[int(answer)]
+
 
 def query_selector(db_type):
     # only import dependencies when needed as they involve installations of external tools/libs.
@@ -137,26 +144,28 @@ def query_selector(db_type):
         from query_sparksql_local import query_sparksql_local
         return query_sparksql_local
     else:
-        raise "unsupported db type: %s"%db_type  # TODO: fix raise.
+        raise "unsupported db type: %s" % db_type  # TODO: fix raise.
+
 
 def write_file(fname, content):
     fh = open(fname, 'w')
     fh.write(content)
     fh.close()
 
+
 def compare_dfs(df1, pks1, compare1, df2, pks2, compare2, strip=True, filter_deltas=True, threshold=0.01):
     """Note: Doesn't support both dfs having same column names (or at least the ones that need to be compared.)"""
     print('Length df1', len(df1), df1[pks1].nunique())
     print('Length df2', len(df2), df2[pks2].nunique())
 
-    if strip :
-        df1 = df1[pks1+compare1]
-        df2 = df2[pks2+compare2]
+    if strip:
+        df1 = df1[pks1 + compare1]
+        df2 = df2[pks2 + compare2]
 
     # Join datasets
-    df_joined = pd.merge(left=df1, right=df2, how='outer', left_on=pks1, right_on=pks2, indicator = True, suffixes=('_1', '_2'))
+    df_joined = pd.merge(left=df1, right=df2, how='outer', left_on=pks1, right_on=pks2, indicator=True, suffixes=('_1', '_2'))
     print('Length df_joined', len(df_joined))
-    df_joined['_no_deltas'] = True # init
+    df_joined['_no_deltas'] = True  # init
 
     def check_delta(row):
         if pd.isna(row[item1]) and pd.isna(row[item2]):
@@ -168,26 +177,25 @@ def compare_dfs(df1, pks1, compare1, df2, pks2, compare2, strip=True, filter_del
         elif float(row[item1]) == 0 or float(row[item2]) == 0:
             return 100
         else:
-            return np.abs(np.divide((row[item1]-row[item2]), float(row[item1])))*100
+            return np.abs(np.divide((row[item1] - row[item2]), float(row[item1]))) * 100
 
     # Check deltas
     np.seterr(divide='ignore')  # to handle the division by 0 in divide().
     for ii in range(len(compare1)):
         item1 = compare1[ii]
         item2 = compare2[ii]
-        assert item1!=item2  # necessary for next step. See comment below.
+        assert item1 != item2  # necessary for next step. See comment below.
         try:
-            df_joined['_delta_'+item1] = df_joined.apply(lambda row: (row[item1] if not pd.isna(row[item1]) else 0.0)-(row[item2] if not pd.isna(row[item2]) else 0.0), axis=1) # need to deal with case where df1 and df2 have same col name and merge adds suffix _1 and _2
-            df_joined['_delta_'+item1+'_%'] = df_joined.apply(check_delta, axis=1)
-            df_joined['_no_deltas'] = df_joined.apply(lambda row: row['_no_deltas']==True and row['_delta_'+item1+'_%']<threshold, axis=1)
+            df_joined['_delta_' + item1] = df_joined.apply(lambda row: (row[item1] if not pd.isna(row[item1]) else 0.0) - (row[item2] if not pd.isna(row[item2]) else 0.0), axis=1)  # need to deal with case where df1 and df2 have same col name and merge adds suffix _1 and _2
+            df_joined['_delta_' + item1 + '_%'] = df_joined.apply(check_delta, axis=1)
+            df_joined['_no_deltas'] = df_joined.apply(lambda row: row['_no_deltas'] == True and row['_delta_' + item1 + '_%'] < threshold, axis=1)
         except Exception as err:
             raise Exception("Failed item={}, error: \n{}".format(item1, err))
 
-
     np.seterr(divide='raise')
     if filter_deltas:
-        df_joined = df_joined[df_joined.apply(lambda row : row['_no_deltas']==False, axis=1)].reset_index()
-    df_joined.sort_values(by=['_merge']+pks1, inplace=True)
+        df_joined = df_joined[df_joined.apply(lambda row: row['_no_deltas'] == False, axis=1)].reset_index()
+    df_joined.sort_values(by=['_merge'] + pks1, inplace=True)
     return df_joined
 
 

--- a/yaetos/libs/analysis_toolkit/query_pandasql.py
+++ b/yaetos/libs/analysis_toolkit/query_pandasql.py
@@ -5,5 +5,5 @@ import pandasql as pdsql
 def query_pandasql(query_str, fname, **kwargs):
     """Nice and fast but doesn't support windowing functions (sqlite limitation)."""
     df = pd.read_csv(fname, **kwargs)
-    df_out = pdsql.sqldf(query_str, {'df':df})
+    df_out = pdsql.sqldf(query_str, {'df': df})
     return df_out

--- a/yaetos/libs/analysis_toolkit/query_sparksql_local.py
+++ b/yaetos/libs/analysis_toolkit/query_sparksql_local.py
@@ -20,7 +20,7 @@ def query_sparksql_local(query_str, fnames_in=None, dfs_in=None, **kwargs):
             print("Input {}, data types: {}".format(name, [(fd.name, fd.dataType) for fd in df.schema.fields]))
 
     if dfs_in:
-        ## Input dfs may require enforced standard types in pandas dfs (no "object"), so they are compatible with spark dfs.
+        # Input dfs may require enforced standard types in pandas dfs (no "object"), so they are compatible with spark dfs.
         for name, df in dfs_in.items():
             df = sc_sql.createDataFrame(df)
             df.createOrReplaceTempView(name)

--- a/yaetos/libs/generic_jobs/dummy_job.py
+++ b/yaetos/libs/generic_jobs/dummy_job.py
@@ -1,6 +1,7 @@
 from yaetos.etl_utils import ETL_Base, Commandliner
 from pyspark.sql.types import StructType
 
+
 class Job(ETL_Base):
     def transform(self):
         return self.sc_sql.createDataFrame([], StructType([]))

--- a/yaetos/libs/generic_jobs/launcher.py
+++ b/yaetos/libs/generic_jobs/launcher.py
@@ -5,4 +5,4 @@ Usage: $ python jobs/generic/launcher.py --job_name=some_job_name_from_manifest
 
 from yaetos.etl_utils import Commandliner
 
-Commandliner(Job=None, launcher_file = 'jobs/generic/launcher.py')
+Commandliner(Job=None, launcher_file='jobs/generic/launcher.py')

--- a/yaetos/libs/pytest_utils/conftest.py
+++ b/yaetos/libs/pytest_utils/conftest.py
@@ -2,34 +2,38 @@ import pytest
 from pyspark import SparkContext
 from pyspark.sql import SQLContext, SparkSession, Row
 
+
 @pytest.fixture(scope="session")
 def sc(request):
     sc = SparkContext(appName='test')
     return sc
 
+
 @pytest.fixture(scope="session")
 def sc_sql(sc):
     return SQLContext(sc)
+
 
 @pytest.fixture(scope="session")
 def ss(sc):  # TODO: check if sc necessary here since not used downstream
     return SparkSession.builder.appName('test').getOrCreate()
 
+
 @pytest.fixture
 def get_pre_jargs():
     def internal_function(input_names=[], pre_jargs_over={}):
         """Requires loaded_inputs or pre_jargs_over"""
-        inputs  = {key: {'type':None} for key in input_names}
+        inputs = {key: {'type': None} for key in input_names}
         pre_jargs = {
             'defaults_args': {
                 'manage_git_info': False,
-                'mode':'dev_local',
-                'deploy':'none',
-                'job_param_file':None,
-                'output': {'type':None},
+                'mode': 'dev_local',
+                'deploy': 'none',
+                'job_param_file': None,
+                'output': {'type': None},
                 'inputs': inputs},
-            'job_args':{},
-            'cmd_args':{}}
+            'job_args': {},
+            'cmd_args': {}}
         if 'defaults_args' in pre_jargs_over.keys():
             pre_jargs['defaults_args'].update(pre_jargs_over['defaults_args'])
         else:

--- a/yaetos/libs/python_db_connectors/query_hive.py
+++ b/yaetos/libs/python_db_connectors/query_hive.py
@@ -25,8 +25,8 @@ def query(query_str, **kwarg):
 
     try:
         cursor.execute(query_str)
-    except Exception as e:
-        raise Exception('Failed running hive query, with error: {}'.format(traceback.format_exc()))
+    except Exception as err:
+        raise Exception('Failed running hive query, with error: {}'.format(err))
 
     columns = [col[0] for col in cursor.description]
     df = pd.DataFrame.from_records(cursor.fetchall(), columns=columns)

--- a/yaetos/libs/python_db_connectors/query_hive.py
+++ b/yaetos/libs/python_db_connectors/query_hive.py
@@ -9,10 +9,10 @@ def connect(db):
     config.read(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'credentials.cfg'))
 
     params = {
-        'user':     config.get(db, 'user'),
-        'host':     config.get(db, 'host'),
-        'port':     config.get(db, 'port') if config.has_option(db, 'port') else "10000",
-        }
+        'user': config.get(db, 'user'),
+        'host': config.get(db, 'host'),
+        'port': config.get(db, 'port') if config.has_option(db, 'port') else "10000",
+    }
     return hive.Connection(host=params['host'], port=params['port'], username=params['user'])
 
 
@@ -25,13 +25,14 @@ def query(query_str, **kwarg):
 
     try:
         cursor.execute(query_str)
-    except :
+    except:
         raise 'Failed running query'
 
     columns = [col[0] for col in cursor.description]
     df = pd.DataFrame.from_records(cursor.fetchall(), columns=columns)
     connection.close()
     return df
+
 
 if __name__ == "__main__":
     df = query("SHOW TABLES", db='name_of_connection_from_credentials_file')

--- a/yaetos/libs/python_db_connectors/query_hive.py
+++ b/yaetos/libs/python_db_connectors/query_hive.py
@@ -25,8 +25,8 @@ def query(query_str, **kwarg):
 
     try:
         cursor.execute(query_str)
-    except:
-        raise 'Failed running query'
+    except Exception as e:
+        raise Exception('Failed running hive query, with error: {}'.format(traceback.format_exc()))
 
     columns = [col[0] for col in cursor.description]
     df = pd.DataFrame.from_records(cursor.fetchall(), columns=columns)

--- a/yaetos/libs/python_db_connectors/query_mysql.py
+++ b/yaetos/libs/python_db_connectors/query_mysql.py
@@ -4,6 +4,7 @@ import os
 from sqlalchemy import create_engine
 # requires pymysql installed.
 
+
 def connect(db, creds_or_file='conf/connections.cfg'):
     config = ConfigParser()
     if isinstance(creds_or_file, str):
@@ -13,21 +14,23 @@ def connect(db, creds_or_file='conf/connections.cfg'):
         config = creds_or_file
 
     params = {
-        'user':     config.get(db, 'user'),
+        'user': config.get(db, 'user'),
         'password': config.get(db, 'password'),
-        'host':     config.get(db, 'host'),
-        'port':     config.get(db, 'port'),
-        'service':  config.get(db, 'service')
+        'host': config.get(db, 'host'),
+        'port': config.get(db, 'port'),
+        'service': config.get(db, 'service')
     }
 
     connection_str = "mysql+pymysql://{user}:{password}@{host}/{service}".format(**params)
     conn = create_engine(connection_str, encoding='UTF8')
     return conn
 
+
 def query(query_str, **connect_args):
     connection = connect(**connect_args)
     df = pd.read_sql(query_str, connection)
     return df
+
 
 if __name__ == "__main__":
     df = query('SELECT * FROM yourtable', db='name_of_connection_from_credentials_file')

--- a/yaetos/libs/python_db_connectors/query_oracle.py
+++ b/yaetos/libs/python_db_connectors/query_oracle.py
@@ -47,8 +47,7 @@ def query(query_str, **connect_args):
     connection = connect(**connect_args)
 
     if (
-        connection.__class__.__doc__ is not None
-        and connection.__class__.__doc__.__contains__("sqlalchemy")
+        connection.__class__.__doc__ is not None and connection.__class__.__doc__.__contains__("sqlalchemy")
     ):  # hasattr(connection, '__class__')
         df = pd.read_sql(query_str, connection, coerce_float=True)
         return df

--- a/yaetos/libs/python_db_connectors/query_redshift.py
+++ b/yaetos/libs/python_db_connectors/query_redshift.py
@@ -3,6 +3,7 @@ from configparser import ConfigParser
 import os
 from sqlalchemy import create_engine
 
+
 def connect(db, creds_or_file='conf/connections.cfg'):
     config = ConfigParser()
     if isinstance(creds_or_file, str):
@@ -12,21 +13,23 @@ def connect(db, creds_or_file='conf/connections.cfg'):
         config = creds_or_file
 
     params = {
-        'user':     config.get(db, 'user'),
+        'user': config.get(db, 'user'),
         'password': config.get(db, 'password'),
-        'host':     config.get(db, 'host'),
-        'port':     config.get(db, 'port'),
-        'service':  config.get(db, 'service')
+        'host': config.get(db, 'host'),
+        'port': config.get(db, 'port'),
+        'service': config.get(db, 'service')
     }
 
     connection_str = "redshift+psycopg2://{user}:{password}@{host}:{port}/{service}".format(**params)
     conn = create_engine(connection_str, encoding='UTF8')
     return conn
 
+
 def query(query_str, **connect_args):
     connection = connect(**connect_args)
     df = pd.read_sql(query_str, connection)
     return df
+
 
 if __name__ == "__main__":
     df = query('SELECT * FROM yourtable', db='name_of_connection_from_credentials_file')

--- a/yaetos/libs/python_db_connectors/query_salesforce.py
+++ b/yaetos/libs/python_db_connectors/query_salesforce.py
@@ -18,6 +18,7 @@ def connect(creds_section, creds_or_file='conf/connections.cfg'):
     domain = None if config.get(creds_section, 'domain') == 'production' else config.get(creds_section, 'domain')
     return Salesforce(username=user, password=pwd, security_token=token, domain=domain)
 
+
 def query(query_str, **connect_args):
     sf = connect(**connect_args)
     resp = sf.query_all(query_str)
@@ -26,6 +27,7 @@ def query(query_str, **connect_args):
         row.__delitem__('attributes')
     df = pd.DataFrame.from_dict(rows)
     return df
+
 
 if __name__ == "__main__":
     df = query('SELECT Account.Name FROM Account', creds_section='name_of_connection_from_credentials_file')

--- a/yaetos/oracle.py
+++ b/yaetos/oracle.py
@@ -23,12 +23,12 @@ def create_table(df, connection_profile, name_tb, schema, types, creds_or_file, 
 if __name__ == '__main__':
     from sqlalchemy import types
     import pandas as pd
-    data = [['aaa',10],['bbb',12],['ccc',3]]
-    df = pd.DataFrame(data,columns=['session_id','count_events'])
+    data = [['aaa', 10], ['bbb', 12], ['ccc', 3]]
+    df = pd.DataFrame(data, columns=['session_id', 'count_events'])
     types = {
         'session_id': types.VARCHAR(16),
         'count_events': types.Integer(),
-        }
+    }
     connection_profile = 'some_connection_profile'
     name_tb = 'test_table'
     create_table(df, connection_profile, name_tb, types)

--- a/yaetos/oracle_sql_job.py
+++ b/yaetos/oracle_sql_job.py
@@ -8,7 +8,7 @@ class Job(ETL_Base):
     """To run/deploy sql jobs, requires --sql_file arg."""
 
     def set_job_file(self):
-        job_file=self.jargs.cmd_args['sql_file']
+        job_file = self.jargs.cmd_args['sql_file']
         # logger.info("job_file: '{}'".format(job_file))
         return job_file
 
@@ -20,7 +20,7 @@ class Job(ETL_Base):
         cred_profiles = Cred_Ops_Dispatcher().retrieve_secrets(self.jargs.storage)
 
         print("Running query: \n", sql)
-        pdf = query_oracle(sql, db=self.db_creds, connection_type='sqlalchemy', creds_or_file=cred_profiles) # for testing locally: from libs.analysis_toolkit.query_helper import process_and_cache; pdf = process_and_cache('test', 'data/', lambda : query_oracle(sql, db=self.db_creds, connection_type='sqlalchemy', creds_or_file=cred_profiles), force_rerun=False)
+        pdf = query_oracle(sql, db=self.db_creds, connection_type='sqlalchemy', creds_or_file=cred_profiles)  # for testing locally: from libs.analysis_toolkit.query_helper import process_and_cache; pdf = process_and_cache('test', 'data/', lambda : query_oracle(sql, db=self.db_creds, connection_type='sqlalchemy', creds_or_file=cred_profiles), force_rerun=False)
         # TODO: Check to get OUTPUT_TYPES from query_oracle, so not required here.
         sdf = pdf_to_sdf(pdf, self.OUTPUT_TYPES, self.sc, self.sc_sql)
         return sdf
@@ -34,13 +34,13 @@ class Job(ETL_Base):
 
     def update_sql_file(self, sql):
         for var_name, table_name in self.INPUTS.iteritems():
-            sql = sql.replace(var_name+' ', table_name+' ')  # TODO: don't require extra space.
+            sql = sql.replace(var_name + ' ', table_name + ' ')  # TODO: don't require extra space.
         return sql
 
     @staticmethod
     def get_output_types_from_sql(sql):
         type_lines = [item.split('-----')[1].split(':') for item in sql.split('\n') if item.startswith('----- ')]
-        output_types = {eval(item[0]):eval('types.'+item[1]) for item in type_lines}
+        output_types = {eval(item[0]): eval('types.' + item[1]) for item in type_lines}
         return output_types
 
 

--- a/yaetos/pandas_utils.py
+++ b/yaetos/pandas_utils.py
@@ -17,11 +17,13 @@ def load_multiple_csvs(path, read_kwargs):
     df = pd.concat((pd.read_csv(f, **read_kwargs) for f in csv_files))
     return df.reset_index(drop=True)
 
+
 def load_multiple_files(path, file_type='csv', read_func='read_csv', read_kwargs={}):
     files = glob.glob(os.path.join(path, "*.{}".format(file_type)))
     func = getattr(pd, read_func)
     df = pd.concat((func(f, **read_kwargs) for f in files))
     return df.reset_index(drop=True)
+
 
 def load_csvs(path, read_kwargs):
     """Loading 1 csv or multiple depending on path"""
@@ -32,6 +34,7 @@ def load_csvs(path, read_kwargs):
         return load_multiple_csvs(path, read_kwargs)
     else:
         raise Exception("Path should end with '.csv' or '/'.".format())
+
 
 def load_df(path, file_type='csv', read_func='read_csv', read_kwargs={}):
     """Loading 1 file or multiple depending on path"""
@@ -51,10 +54,12 @@ def create_subfolders(path):
     output_dir = Path(path).parent
     output_dir.mkdir(parents=True, exist_ok=True)
 
+
 def save_pandas_csv_local(df, path):
     # TODO: to be made obsolete once save_pandas_local works
     create_subfolders(path)
     df.to_csv(path)
+
 
 def save_pandas_local(df, path, save_method='to_csv', save_kwargs={}):
     if isinstance(path, str):  # to deal with case when path is StringIO

--- a/yaetos/redshift_pandas.py
+++ b/yaetos/redshift_pandas.py
@@ -23,12 +23,12 @@ def create_table(df, connection_profile, name_tb, schema, types, creds_or_file, 
 if __name__ == '__main__':
     from sqlalchemy import types
     import pandas as pd
-    data = [['aaa',10],['bbb',12],['ccc',3]]
-    df = pd.DataFrame(data,columns=['session_id','count_events'])
+    data = [['aaa', 10], ['bbb', 12], ['ccc', 3]]
+    df = pd.DataFrame(data, columns=['session_id', 'count_events'])
     types = {
         'session_id': types.VARCHAR(16),
         'count_events': types.Integer(),
-        }
+    }
     connection_profile = 'some_connection_profile'
     name_tb = 'test_table'
     create_table(df, connection_profile, name_tb, types)

--- a/yaetos/scripts/copy/ex0_extraction_job.py
+++ b/yaetos/scripts/copy/ex0_extraction_job.py
@@ -13,8 +13,8 @@ class Job(ETL_Base):
 
         # Save to local
         tmp_dir = 'tmp'
-        os.makedirs(tmp_dir, exist_ok = True)
-        local_path = tmp_dir+'/tmp_file.csv.gz'
+        os.makedirs(tmp_dir, exist_ok=True)
+        local_path = tmp_dir + '/tmp_file.csv.gz'
         open(local_path, 'wb').write(resp.content)  # creating local copy, necessary for sc_sql.read.csv, TODO: check to remove local copy step.
         self.logger.info('Copied file locally at {}.'.format(local_path))
 

--- a/yaetos/scripts/copy/ex1_frameworked_job_test.py
+++ b/yaetos/scripts/copy/ex1_frameworked_job_test.py
@@ -8,20 +8,20 @@ class Test_Job(object):
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1235, 'action': 'searchResultPage', 'n_results': 1},
-            {'session_id': 1236, 'action': 'other',            'n_results': 1},
-            ]))
+            {'session_id': 1236, 'action': 'other', 'n_results': 1},
+        ]))
 
         other_events = ss.read.json(sc.parallelize([
             {'session_id': 1234, 'other': 1},
             {'session_id': 1235, 'other': 1},
             {'session_id': 1236, 'other': 1},
-            ]))
+        ]))
 
         expected = [
             {'session_id': 1234, 'count_events': 2},
             {'session_id': 1235, 'count_events': 1},
-            ]
+        ]
 
-        loaded_inputs={'some_events': some_events, 'other_events':other_events}
+        loaded_inputs = {'some_events': some_events, 'other_events': other_events}
         actual = Job(pre_jargs=get_pre_jargs(loaded_inputs.keys())).etl_no_io(sc, sc_sql, loaded_inputs=loaded_inputs)[0].toPandas().to_dict(orient='records')
         assert actual == expected

--- a/yaetos/scripts/copy/ex1_full_sql_job_test.py
+++ b/yaetos/scripts/copy/ex1_full_sql_job_test.py
@@ -8,23 +8,23 @@ class Test_Job(object):
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1234, 'action': 'searchResultPage', 'n_results': 1},
             {'session_id': 1235, 'action': 'searchResultPage', 'n_results': 1},
-            {'session_id': 1236, 'action': 'other',            'n_results': 1},
-            ]))
+            {'session_id': 1236, 'action': 'other', 'n_results': 1},
+        ]))
 
         other_events = ss.read.json(sc.parallelize([
             {'session_id': 1234, 'other': 1},
             {'session_id': 1235, 'other': 1},
             {'session_id': 1236, 'other': 1},
-            ]))
+        ]))
 
         expected = [
             {'session_id': 1234, 'count_events': 2},
             {'session_id': 1235, 'count_events': 1},
-            ]
+        ]
 
         sql_file = 'jobs/examples/ex1_full_sql_job.sql'
 
-        loaded_inputs={'some_events': some_events, 'other_events':other_events}
+        loaded_inputs = {'some_events': some_events, 'other_events': other_events}
         pre_jargs = get_pre_jargs(loaded_inputs.keys())
         pre_jargs['cmd_args']['sql_file'] = sql_file
         actual = Job(pre_jargs=pre_jargs).etl_no_io(sc, sc_sql, loaded_inputs=loaded_inputs)[0].toPandas().to_dict(orient='records')

--- a/yaetos/scripts/yaetos_cmdline.py
+++ b/yaetos/scripts/yaetos_cmdline.py
@@ -51,7 +51,7 @@ class YaetosCmds(object):
             print('Unrecognized command')
             parser.print_help()
             exit(1)
-        getattr(self, args.command)() # dispatching according to command line.
+        getattr(self, args.command)()  # dispatching according to command line.
 
     def setup(self):
         parser = argparse.ArgumentParser(
@@ -64,7 +64,7 @@ class YaetosCmds(object):
         parser = argparse.ArgumentParser(
             description=self.usage_docker_bash)
         # parser.add_argument('--no_aws', action='store_true')  # TODO: implement
-        subprocess.call("./launch_env.sh 1", shell=True) # TODO: make it work with better: subprocess.call(["./launch_env.sh", '1'])
+        subprocess.call("./launch_env.sh 1", shell=True)  # TODO: make it work with better: subprocess.call(["./launch_env.sh", '1'])
 
     def launch_docker_jupyter(self):
         parser = argparse.ArgumentParser(
@@ -75,8 +75,8 @@ class YaetosCmds(object):
         parser = argparse.ArgumentParser(
             description=self.usage_run_dockerized)
         ignored, cmd_unknown_args = parser.parse_known_args()
-        cmd_str = 'python '+' '.join(cmd_unknown_args[1:])
-        cmd_delegated = "./launch_env.sh 3 "+cmd_str
+        cmd_str = 'python ' + ' '.join(cmd_unknown_args[1:])
+        cmd_delegated = "./launch_env.sh 3 " + cmd_str
         # print("Command line to be sent "+cmd_delegated)
         subprocess.call(cmd_delegated, shell=True)
 
@@ -84,8 +84,8 @@ class YaetosCmds(object):
         parser = argparse.ArgumentParser(
             description=self.usage_run)
         ignored, cmd_unknown_args = parser.parse_known_args()
-        cmd_str = 'python '+' '.join(cmd_unknown_args[1:])
-        cmd_delegated = "./launch_env.sh 4 "+cmd_str
+        cmd_str = 'python ' + ' '.join(cmd_unknown_args[1:])
+        cmd_delegated = "./launch_env.sh 4 " + cmd_str
         subprocess.call(cmd_delegated, shell=True)
 
 
@@ -95,7 +95,7 @@ def setup_env(args):
 
     paths = yaetos.__path__
     package_path = paths[0]
-    if len(paths) > 1 :
+    if len(paths) > 1:
         print(f'Yeatos python package found in several locations. The script will use this one: {package_path}')
 
     # Empty folders necessary for later.

--- a/yaetos/spark_utils.py
+++ b/yaetos/spark_utils.py
@@ -14,14 +14,16 @@ except ModuleNotFoundError or ImportError:
 
 
 def identify_non_unique_pks(df, pks):
-    windowSpec  = Window.partitionBy([F.col(item) for item in pks])
+    windowSpec = Window.partitionBy([F.col(item) for item in pks])
     df = df.withColumn('_count_pk', F.count('*').over(windowSpec)) \
         .where(F.col('_count_pk') >= 2)
     # Debug: df.repartition(1).write.mode('overwrite').option("header", "true").csv('data/sandbox/non_unique_test/')
     return df
 
+
 def add_created_at(sdf, start_dt):
     return sdf.withColumn('_created_at', F.lit(start_dt))
+
 
 def create_empty_sdf(sc_sql):
     return sc_sql.createDataFrame([], StructType([]))

--- a/yaetos/sql_job.py
+++ b/yaetos/sql_job.py
@@ -6,7 +6,7 @@ class Job(ETL_Base):
 
     def set_jargs(self, pre_jargs, loaded_inputs={}):
         # Function called only if running the job directly, i.e. "python yaetos/sql_job.py --sql_file=jobs/some_job.sql", ignored if running from "python jobs/generic/launcher.py --job_name=some_job.sql"
-        sql_file=pre_jargs['cmd_args']['sql_file']
+        sql_file = pre_jargs['cmd_args']['sql_file']
         job_name = Job_Yml_Parser.set_job_name_from_file(sql_file)
         pre_jargs['job_args']['job_name'] = job_name
         return Job_Args_Parser(defaults_args=pre_jargs['defaults_args'], yml_args=None, job_args=pre_jargs['job_args'], cmd_args=pre_jargs['cmd_args'], loaded_inputs=loaded_inputs)


### PR DESCRIPTION
Dealing with basic pep8 formatting issues. Basic PEP8 formatting is now enforced. Specific PEP8 rules are not enforced yet (E501,C901,E402,W605,F401,F841).

This is a follow up to https://github.com/arthurprevot/yaetos/pull/72, and another chunk from https://github.com/arthurprevot/yaetos/pull/70. This PR touches a lot of code but should be safe. I ran autopep8 commands, like `autopep8 --in-place --ignore=E501,C901,E402,W605 --recursive yaetos/`, i.e. not using the "--aggressive" options, i.e. mostly dealing with white space and few minor code updates.

This is another step towards https://github.com/arthurprevot/yaetos/issues/69 from @AlejandroUPC .
