### PR TITLE
deploy to EMR from windows, outside docker

### DIFF
--- a/conf/aws_config.cfg.example
+++ b/conf/aws_config.cfg.example
@@ -1,5 +1,5 @@
 [dev]
-profile_name         : default
+profile_name         : to_be_filled
 ec2_key_name         : to_be_filled
 user                 : to_be_filled
 s3_bucket_logs       : to_be_filled
@@ -8,7 +8,7 @@ ec2_subnet_id        : to_be_filled
 extra_security_gp    : None
 
 [prod]
-profile_name         : default
+profile_name         : to_be_filled
 ec2_key_name         : to_be_filled
 user                 : to_be_filled
 s3_bucket_logs       : to_be_filled

--- a/conf/aws_config.cfg.example
+++ b/conf/aws_config.cfg.example
@@ -1,5 +1,5 @@
 [dev]
-profile_name         : to_be_filled
+profile_name         : default
 ec2_key_name         : to_be_filled
 user                 : to_be_filled
 s3_bucket_logs       : to_be_filled
@@ -8,7 +8,7 @@ ec2_subnet_id        : to_be_filled
 extra_security_gp    : None
 
 [prod]
-profile_name         : to_be_filled
+profile_name         : default
 ec2_key_name         : to_be_filled
 user                 : to_be_filled
 s3_bucket_logs       : to_be_filled

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ copyright = '2018, Arthur Prevot'
 author = 'Arthur Prevot'
 
 release = '0.9'
-version = '0.9.20'
+version = '0.9.21'
 
 # -- General configuration
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/guides/single-sourcing-package-version/
-    version='0.9.20',  # Required
+    version='0.9.21',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,3 +46,14 @@ def get_pre_jargs():
             pre_jargs.update(pre_jargs_over)
         return pre_jargs
     return internal_function
+
+
+@pytest.fixture
+def deploy_args():
+    return {'aws_setup': 'dev',
+            'aws_config_file': 'conf/aws_config.cfg'}
+
+
+@pytest.fixture
+def app_args():
+    return {'py_job': 'some/job.py', 'job_name': 'some_job_name'}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def get_pre_jargs():
 @pytest.fixture
 def deploy_args():
     return {'aws_setup': 'dev',
-            'aws_config_file': 'conf/aws_config.cfg',
+            'aws_config_file': 'conf/aws_config.cfg.example',
             'mode': 'dev_EMR'}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,8 @@ def get_pre_jargs():
 @pytest.fixture
 def deploy_args():
     return {'aws_setup': 'dev',
-            'aws_config_file': 'conf/aws_config.cfg'}
+            'aws_config_file': 'conf/aws_config.cfg',
+            'mode': 'dev_EMR'}
 
 
 @pytest.fixture

--- a/tests/yaetos/deploy_test.py
+++ b/tests/yaetos/deploy_test.py
@@ -1,7 +1,4 @@
-# from pandas.testing import assert_frame_equal
-# import pandas as pd
-# import numpy as np
-from yaetos.deploy import DeployPySparkScriptOnAws as dep
+from yaetos.deploy import DeployPySparkScriptOnAws as Dep
 
 
 class Test_DeployPySparkScriptOnAws(object):
@@ -9,12 +6,26 @@ class Test_DeployPySparkScriptOnAws(object):
         mode = 'dev_EMR'
         job_name = 'jobs.some_folder.job'
         user = 'n/a'
-        actual = dep.generate_pipeline_name(mode, job_name, user)
+        actual = Dep.generate_pipeline_name(mode, job_name, user)
         expected = 'yaetos__dev__jobs_d_some_folder_d_job__20220629T205103'
         assert actual[:-15] == expected[:-15]
 
     def test_get_job_name(self):
         pipeline_name = 'yaetos__dev__jobs_d_some_folder_d_job__20220629T205103'
-        actual = dep.get_job_name(pipeline_name)
+        actual = Dep.get_job_name(pipeline_name)
         expected = 'jobs.some_folder.job'
         assert actual == expected
+
+    def test_get_job_log_path_prod(self, deploy_args, app_args):
+        deploy_args = {'mode': 'prod_EMR', **deploy_args}
+        dep = Dep(deploy_args, app_args)
+        actual = dep.get_job_log_path()
+        expected = 'pipelines_metadata/jobs_code/production'
+        assert actual == expected
+
+    def test_get_job_log_path_dev(self, deploy_args, app_args):
+        deploy_args = {'mode': 'dev_EMR', **deploy_args}
+        dep = Dep(deploy_args, app_args)
+        actual = dep.get_job_log_path()
+        expected = 'pipelines_metadata/jobs_code/yaetos__dev__some_job_name__20220629T211146'
+        assert actual[:-15] == expected[:-15]

--- a/tests/yaetos/deploy_test.py
+++ b/tests/yaetos/deploy_test.py
@@ -1,4 +1,6 @@
 from yaetos.deploy import DeployPySparkScriptOnAws as Dep
+import os
+from pathlib import Path as Pt
 
 
 class Test_DeployPySparkScriptOnAws(object):
@@ -8,7 +10,7 @@ class Test_DeployPySparkScriptOnAws(object):
         user = 'n/a'
         actual = Dep.generate_pipeline_name(mode, job_name, user)
         expected = 'yaetos__dev__jobs_d_some_folder_d_job__20220629T205103'
-        assert actual[:-15] == expected[:-15]
+        assert actual[:-15] == expected[:-15]  # [:-15] to remove timestamp
 
     def test_get_job_name(self):
         pipeline_name = 'yaetos__dev__jobs_d_some_folder_d_job__20220629T205103'
@@ -17,15 +19,22 @@ class Test_DeployPySparkScriptOnAws(object):
         assert actual == expected
 
     def test_get_job_log_path_prod(self, deploy_args, app_args):
-        deploy_args = {'mode': 'prod_EMR', **deploy_args}
+        deploy_args['mode'] = 'prod_EMR'
         dep = Dep(deploy_args, app_args)
         actual = dep.get_job_log_path()
         expected = 'pipelines_metadata/jobs_code/production'
         assert actual == expected
 
     def test_get_job_log_path_dev(self, deploy_args, app_args):
-        deploy_args = {'mode': 'dev_EMR', **deploy_args}
+        deploy_args['mode'] = 'dev_EMR'
         dep = Dep(deploy_args, app_args)
         actual = dep.get_job_log_path()
         expected = 'pipelines_metadata/jobs_code/yaetos__dev__some_job_name__20220629T211146'
-        assert actual[:-15] == expected[:-15]
+        assert actual[:-15] == expected[:-15]  # [:-15] to remove timestamp
+
+    def test_get_package_path(self, deploy_args, app_args):
+        app_args['code_source'] = 'repo'
+        dep = Dep(deploy_args, app_args)
+        actual = dep.get_package_path()
+        expected = Pt(os.environ.get('YAETOS_FRAMEWORK_HOME', ''))
+        assert actual == expected

--- a/tests/yaetos/deploy_test.py
+++ b/tests/yaetos/deploy_test.py
@@ -1,0 +1,20 @@
+# from pandas.testing import assert_frame_equal
+# import pandas as pd
+# import numpy as np
+from yaetos.deploy import DeployPySparkScriptOnAws as dep
+
+
+class Test_DeployPySparkScriptOnAws(object):
+    def test_generate_pipeline_name(self):
+        mode = 'dev_EMR'
+        job_name = 'jobs.some_folder.job'
+        user = 'n/a'
+        actual = dep.generate_pipeline_name(mode, job_name, user)
+        expected = 'yaetos__dev__jobs_d_some_folder_d_job__20220629T205103'
+        assert actual[:-15] == expected[:-15]
+
+    def test_get_job_name(self):
+        pipeline_name = 'yaetos__dev__jobs_d_some_folder_d_job__20220629T205103'
+        actual = dep.get_job_name(pipeline_name)
+        expected = 'jobs.some_folder.job'
+        assert actual == expected

--- a/tests/yaetos/deploy_test.py
+++ b/tests/yaetos/deploy_test.py
@@ -33,7 +33,7 @@ class Test_DeployPySparkScriptOnAws(object):
         assert actual[:-15] == expected[:-15]  # [:-15] to remove timestamp
 
     def test_get_package_path(self, deploy_args, app_args):
-        app_args['code_source'] = 'repo'
+        app_args['code_source'] = 'repo'  # TODO: other test for 'lib'
         dep = Dep(deploy_args, app_args)
         actual = dep.get_package_path()
         expected = Pt(os.environ.get('YAETOS_FRAMEWORK_HOME', ''))

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -234,7 +234,6 @@ class DeployPySparkScriptOnAws(object):
     def tar_python_scripts(self):
         package = self.get_package_path()
         output_path = self.TMP / "scripts.tar.gz"
-        logger.info(f"### output_path:{output_path}")
 
         # Create tar.gz file
         t_file = tarfile.open(output_path, 'w:gz')
@@ -442,8 +441,7 @@ class DeployPySparkScriptOnAws(object):
         )
         response_code = response['ResponseMetadata']['HTTPStatusCode']
         if response_code == 200:
-            logger.debug("Added step 'run setup'.")
-            logger.info("### - added step : s3://{}/setup_master.sh".format(self.package_path_with_bucket))
+            logger.debug(f"Added step 'run setup', using s3://{self.package_path_with_bucket}/setup_master.sh")
         else:
             raise Exception("Step couldn't be added")
         time.sleep(1)  # Prevent ThrottlingException

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -314,25 +314,19 @@ class DeployPySparkScriptOnAws(object):
         """
         Move the PySpark + bash scripts to the S3 bucket we use to store temporary files
         """
-        setup_master = '/setup_master.sh' if self.deploy_args.get('spark_version', '2.4') == '2.4' else '/setup_master_alt.sh'
-        setup_nodes = '/setup_nodes.sh' if self.deploy_args.get('spark_version', '2.4') == '2.4' else '/setup_nodes_alt.sh'
+        setup_master = 'setup_master.sh' if self.deploy_args.get('spark_version', '2.4') == '2.4' else 'setup_master_alt.sh'
+        setup_nodes = 'setup_nodes.sh' if self.deploy_args.get('spark_version', '2.4') == '2.4' else 'setup_nodes_alt.sh'
 
-        logger.info(f"#### - upload_temp_files from: {str(self.TMP) + setup_master}")
-        logger.info(f"#### - upload_temp_files to: {self.s3_bucket_logs, self.package_path + '/setup_master.sh'}")
-        logger.info(f"####2 {str(self.TMP / setup_master)}")
-        logger.info(f"####3 {str(self.TMP / Pt(setup_master))}")
-        # import ipdb; ipdb.set_trace()
         # Looping through all 4 steps below doesn't work (Fails silently) so done 1 by 1.
         s3.Object(self.s3_bucket_logs, self.package_path + '/setup_master.sh')\
-          .put(Body=open(str(self.TMP) + setup_master, 'rb'), ContentType='text/x-sh')
+          .put(Body=open(str(self.TMP / setup_master), 'rb'), ContentType='text/x-sh')
         s3.Object(self.s3_bucket_logs, self.package_path + '/setup_nodes.sh')\
-          .put(Body=open(str(self.TMP) + setup_nodes, 'rb'), ContentType='text/x-sh')
+          .put(Body=open(str(self.TMP / setup_nodes), 'rb'), ContentType='text/x-sh')
         s3.Object(self.s3_bucket_logs, self.package_path + '/terminate_idle_cluster.sh')\
-          .put(Body=open(str(self.TMP) + '/terminate_idle_cluster.sh', 'rb'), ContentType='text/x-sh')
+          .put(Body=open(str(self.TMP / 'terminate_idle_cluster.sh'), 'rb'), ContentType='text/x-sh')
         s3.Object(self.s3_bucket_logs, self.package_path + '/scripts.tar.gz')\
-          .put(Body=open(str(self.TMP) + '/scripts.tar.gz', 'rb'), ContentType='application/x-tar')
-        logger.info("Uploaded job files (scripts.tar.gz, {}, {}, terminate_idle_cluster.sh) to bucket path '{}/{}'".format(setup_master, setup_nodes, self.s3_bucket_logs, self.package_path))
-        # raise
+          .put(Body=open(str(self.TMP / 'scripts.tar.gz'), 'rb'), ContentType='application/x-tar')
+        logger.info(f"Uploaded job files (scripts.tar.gz, {setup_master}, {setup_nodes}, terminate_idle_cluster.sh) to bucket path '{self.s3_bucket_logs}/{self.package_path}'")
         return True
 
     def remove_temp_files(self, s3):

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -303,7 +303,7 @@ class DeployPySparkScriptOnAws(object):
             bases = site.getsitepackages()
             if len(bases) > 1:
                 logger.info("There is more than one source of code to ship to EMR '{}'. Will continue with the first one.".format(bases))
-            base = Pt(bases[0]) #+ '/'
+            base = Pt(bases[0])
         elif self.app_args['code_source'] == 'repo':
             base = Pt(eu.LOCAL_FRAMEWORK_FOLDER)
         logger.debug("Source of yaetos code to be shipped: {}".format(base / 'yaetos/'))

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -294,6 +294,11 @@ class DeployPySparkScriptOnAws(object):
         for item in ['setup_master.sh', 'setup_master_alt.sh', 'setup_nodes.sh', 'setup_nodes_alt.sh', 'terminate_idle_cluster.sh']:
             source = package / self.SCRIPTS / item
             destination = self.TMP / item
+            # import ipdb; ipdb.set_trace()
+            # if 'win' in sys.platform:
+            if os.name != 'posix':
+                from yaetos.windows_utils import convert_to_linux_eol
+                convert_to_linux_eol(source, source)
             copyfile(source, destination)
             logger.info(f"### source:{source}, dest {destination}")
         logger.debug("Added all EMR setup files to {}".format(self.TMP))

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -319,7 +319,8 @@ class DeployPySparkScriptOnAws(object):
         setup_master = '/setup_master.sh' if self.deploy_args.get('spark_version', '2.4') == '2.4' else '/setup_master_alt.sh'
         setup_nodes = '/setup_nodes.sh' if self.deploy_args.get('spark_version', '2.4') == '2.4' else '/setup_nodes_alt.sh'
 
-        logger.info(f"####1 - upload_temp_files: {str(self.TMP) + setup_master}")
+        logger.info(f"#### - upload_temp_files from: {str(self.TMP) + setup_master}")
+        logger.info(f"#### - upload_temp_files to: {self.s3_bucket_logs, self.package_path + '/setup_master.sh'}")
         logger.info(f"####2 {str(self.TMP / setup_master)}")
         logger.info(f"####3 {str(self.TMP / Pt(setup_master))}")
         # import ipdb; ipdb.set_trace()

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -312,8 +312,8 @@ class DeployPySparkScriptOnAws(object):
         """
         Move the PySpark + bash scripts to the S3 bucket we use to store temporary files
         """
-        setup_master = 'setup_master.sh' if self.deploy_args.get('spark_version', '2.4') == '2.4' else '/setup_master_alt.sh'
-        setup_nodes = 'setup_nodes.sh' if self.deploy_args.get('spark_version', '2.4') == '2.4' else '/setup_nodes_alt.sh'
+        setup_master = '/setup_master.sh' if self.deploy_args.get('spark_version', '2.4') == '2.4' else '/setup_master_alt.sh'
+        setup_nodes = '/setup_nodes.sh' if self.deploy_args.get('spark_version', '2.4') == '2.4' else '/setup_nodes_alt.sh'
 
         # Looping through all 4 steps below doesn't work (Fails silently) so done 1 by 1.
         s3.Object(self.s3_bucket_logs, self.package_path + '/setup_master.sh')\

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -65,7 +65,6 @@ class DeployPySparkScriptOnAws(object):
         self.job_log_path_with_bucket = '{}/{}'.format(self.s3_bucket_logs, self.job_log_path)   # format: bucket-tempo/yaetos/logs/some_job.some_user.20181204.153429
         self.package_path = self.job_log_path + '/code_package'   # format: yaetos/logs/some_job.some_user.20181204.153429/package
         self.package_path_with_bucket = self.job_log_path_with_bucket + '/code_package'   # format: bucket-tempo/yaetos/logs/some_job.some_user.20181204.153429/package
-        self.session = boto3.Session(profile_name=self.profile_name)  # aka AWS IAM profile
 
         spark_version = self.deploy_args.get('spark_version', '2.4')
         # import ipdb; ipdb.set_trace()
@@ -90,6 +89,7 @@ class DeployPySparkScriptOnAws(object):
         if self.continue_post_git_check() is False:
             return False
 
+        self.session = boto3.Session(profile_name=self.profile_name)  # aka AWS IAM profile
         if self.deploy_args['deploy'] == 'EMR':
             self.run_direct()
         elif self.deploy_args['deploy'] in ('EMR_Scheduled', 'EMR_DataPipeTest'):

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -294,9 +294,9 @@ class DeployPySparkScriptOnAws(object):
         for item in ['setup_master.sh', 'setup_master_alt.sh', 'setup_nodes.sh', 'setup_nodes_alt.sh', 'terminate_idle_cluster.sh']:
             source = package / self.SCRIPTS / item
             destination = self.TMP / item
-            # import ipdb; ipdb.set_trace()
+            #import ipdb; ipdb.set_trace()
             # if 'win' in sys.platform:
-            if os.name != 'posix':
+            if os.name == 'nt':  # i.e. windows
                 from yaetos.windows_utils import convert_to_linux_eol
                 convert_to_linux_eol(source, source)
             copyfile(source, destination)

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -197,12 +197,10 @@ class DeployPySparkScriptOnAws(object):
     def generate_pipeline_name(mode, job_name, user):
         """Opposite of get_job_name()"""
         mode_label = {'dev_EMR': 'dev', 'prod_EMR': 'prod'}[mode]
-        name = "yaetos__{mode_label}__{pname}__{time}".format(
-            mode_label=mode_label,
-            pname=job_name.replace('.', '_d_').replace('/', '_s_'),
-            # user.replace('.','_'),
-            time=datetime.now().strftime("%Y%m%dT%H%M%S"))
-        print('Pipeline Name "{}":'.format(name))
+        pname = job_name.replace('.', '_d_').replace('/', '_s_')
+        now = datetime.now().strftime("%Y%m%dT%H%M%S")
+        name = f"yaetos__{mode_label}__{pname}__{now}"
+        logger.info('Pipeline Name "{}":'.format(name))
         return name
 
     @staticmethod

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -187,8 +187,8 @@ class DeployPySparkScriptOnAws(object):
                     'name': None}
 
         clusters.append((len(clusters) + 1, None, 'Create a new cluster'))
-        logger.info('Clusters found for AWS account "%s":' % (self.aws_setup))
-        logger.info('\n'.join(['[%s] %s' % (item[0], item[2]) for item in clusters]))
+        print('Clusters found for AWS account "%s":' % (self.aws_setup))
+        print('\n'.join(['[%s] %s' % (item[0], item[2]) for item in clusters]))
         answer = input('Your choice ? ')
         return {'id': clusters[int(answer) - 1][1],
                 'name': clusters[int(answer) - 1][2]}

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -286,7 +286,7 @@ class DeployPySparkScriptOnAws(object):
         logger.debug("Added all spark app files to {}".format(output_path))
 
     def move_bash_to_local_temp(self):
-        """Moving file from local ... to local tmp folder for later upload to S3."""
+        """Moving file from local repo to local tmp folder for later upload to S3."""
         package = self.get_package_path()
         for item in ['setup_master.sh', 'setup_master_alt.sh', 'setup_nodes.sh', 'setup_nodes_alt.sh', 'terminate_idle_cluster.sh']:
             source = package / self.SCRIPTS / item

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -292,13 +292,8 @@ class DeployPySparkScriptOnAws(object):
         for item in ['setup_master.sh', 'setup_master_alt.sh', 'setup_nodes.sh', 'setup_nodes_alt.sh', 'terminate_idle_cluster.sh']:
             source = package / self.SCRIPTS / item
             destination = self.TMP / item
-            #import ipdb; ipdb.set_trace()
-            # if 'win' in sys.platform:
-            if os.name == 'nt':  # i.e. windows
-                from yaetos.windows_utils import convert_to_linux_eol
-                convert_to_linux_eol(source, source)
+            convert_to_linux_eol_if_needed(source)
             copyfile(source, destination)
-            logger.info(f"### source:{source}, dest {destination}")
         logger.debug("Added all EMR setup files to {}".format(self.TMP))
 
     def get_package_path(self):
@@ -734,6 +729,13 @@ def deploy_all_scheduled():
             continue
 
         DeployPySparkScriptOnAws(deploy_args, app_args).run()
+
+
+def convert_to_linux_eol_if_needed(fname):
+    """ Function needed when running from windows to avoid error registering AWS EMR step : 'No such file or directory'"""
+    if os.name == 'nt':
+        from yaetos.windows_utils import convert_to_linux_eol  # loaded here to remove dependency for non windows users.
+        convert_to_linux_eol(fname, fname)
 
 
 def terminate(error_message=None):

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -451,6 +451,7 @@ class DeployPySparkScriptOnAws(object):
         response_code = response['ResponseMetadata']['HTTPStatusCode']
         if response_code == 200:
             logger.debug("Added step 'run setup'.")
+            logger.info("### - added step : s3://{}/setup_master.sh".format(self.package_path_with_bucket))
         else:
             raise Exception("Step couldn't be added")
         time.sleep(1)  # Prevent ThrottlingException

--- a/yaetos/scripts/copy/Dockerfile_external
+++ b/yaetos/scripts/copy/Dockerfile_external
@@ -3,7 +3,7 @@ USER root
 
 # Pip installs
 RUN apt-get update && apt-get install -y git
-RUN pip3 install --no-deps yaetos==0.9.20
+RUN pip3 install --no-deps yaetos==0.9.21
 # Force latest version to avoid using previous ones.
 RUN pip3 install -r /opt/bitnami/python/lib/python3.6/site-packages/yaetos/scripts/requirements_alt.txt
 # TODO: check to put all yaetos requirements in package def to avoid having to call it separately.

--- a/yaetos/windows_utils.py
+++ b/yaetos/windows_utils.py
@@ -12,11 +12,11 @@ def convert_to_linux_eol(path_in, path_out):
     # # relative or absolute file path, e.g.:
     # file_path = in_path
 
-    with open(file_path, 'rb') as open_file:
+    with open(path_in, 'rb') as open_file:
         content = open_file.read()
 
     content = content.replace(WINDOWS_LINE_ENDING, UNIX_LINE_ENDING)
 
-    with open(file_path, 'wb') as open_file:
+    with open(path_out, 'wb') as open_file:
         open_file.write(content)
     return True

--- a/yaetos/windows_utils.py
+++ b/yaetos/windows_utils.py
@@ -2,6 +2,7 @@
 WINDOWS_LINE_ENDING = b'\r\n'
 UNIX_LINE_ENDING = b'\n'
 
+
 def convert_to_linux_eol(path_in, path_out):
     """path_in can be absolute or relative, same for path_out.
     path_out can be the same as path_in, i.e. replacing in place."""

--- a/yaetos/windows_utils.py
+++ b/yaetos/windows_utils.py
@@ -1,0 +1,22 @@
+from yaetos.logger import setup_logging
+logger = setup_logging('Job')
+
+# replacement strings
+WINDOWS_LINE_ENDING = b'\r\n'
+UNIX_LINE_ENDING = b'\n'
+
+def convert_to_linux_eol(path_in, path_out):
+    """
+    path_in can be absolute or relative, same for path_out.
+    path_out can be the same as path_in, i.e. replacing in place."""
+    # # relative or absolute file path, e.g.:
+    # file_path = in_path
+
+    with open(file_path, 'rb') as open_file:
+        content = open_file.read()
+
+    content = content.replace(WINDOWS_LINE_ENDING, UNIX_LINE_ENDING)
+
+    with open(file_path, 'wb') as open_file:
+        open_file.write(content)
+    return True

--- a/yaetos/windows_utils.py
+++ b/yaetos/windows_utils.py
@@ -1,17 +1,10 @@
-from yaetos.logger import setup_logging
-logger = setup_logging('Job')
-
 # replacement strings
 WINDOWS_LINE_ENDING = b'\r\n'
 UNIX_LINE_ENDING = b'\n'
 
 def convert_to_linux_eol(path_in, path_out):
-    """
-    path_in can be absolute or relative, same for path_out.
+    """path_in can be absolute or relative, same for path_out.
     path_out can be the same as path_in, i.e. replacing in place."""
-    # # relative or absolute file path, e.g.:
-    # file_path = in_path
-
     with open(path_in, 'rb') as open_file:
         content = open_file.read()
 


### PR DESCRIPTION
Update to make local paths cross platform to deploy code to EMR from windows. Involves:
 * using pathlib
 * dealing with files with crlf end of line (windows), forced to lf (linux/mac) since not supported by AWS EMR steps. 

Other:
 * Added first tests for deploy.py
 * print -> logger.info

Moved to v0.9.21, published