### PR TITLE
Fix redshift jar + improve jar management

### DIFF
--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -300,7 +300,7 @@ common_params:
       schema: frontroom
       emr_core_instances: 0
       aws_config_file:  conf/aws_config.cfg
-      aws_setup:        dev
+      aws_setup:        pro
       jobs_folder:      jobs/
       load_connectors: all
       enable_redshift_push: True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ copyright = '2018, Arthur Prevot'
 author = 'Arthur Prevot'
 
 release = '0.9'
-version = '0.9.28'
+version = '0.9.29'
 
 # -- General configuration
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/guides/single-sourcing-package-version/
-    version='0.9.28',  # Required
+    version='0.9.29',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -504,8 +504,6 @@ class DeployPySparkScriptOnAws(object):
             "spark-submit",
             "--verbose",
             "--py-files={}scripts.zip".format(eu.CLUSTER_APP_FOLDER),
-            #"--packages={}".format(package_str),
-            #"--jars={}".format(eu.JARS),
         ]
         if app_args.get('load_connectors', '') == 'all':
             package = eu.PACKAGES_EMR if self.deploy_args.get('spark_version', '2.4') == '2.4' else eu.PACKAGES_EMR_ALT

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -499,16 +499,22 @@ class DeployPySparkScriptOnAws(object):
 
         emr_mode = 'dev_EMR' if app_args['mode'] == 'dev_local' else app_args['mode']
         launcher_file = app_args.get('launcher_file') or app_file
-        package = eu.PACKAGES_EMR if self.deploy_args.get('spark_version', '2.4') == '2.4' else eu.PACKAGES_EMR_ALT
-        package_str = ','.join(package)
 
         spark_submit_args = [
             "spark-submit",
             "--verbose",
             "--py-files={}scripts.zip".format(eu.CLUSTER_APP_FOLDER),
-            "--packages={}".format(package_str),
-            "--jars={}".format(eu.JARS),
+            #"--packages={}".format(package_str),
+            #"--jars={}".format(eu.JARS),
         ]
+        if app_args.get('load_connectors', '') == 'all':
+            package = eu.PACKAGES_EMR if self.deploy_args.get('spark_version', '2.4') == '2.4' else eu.PACKAGES_EMR_ALT
+            package_str = ','.join(package)
+            pac = [f"--packages={app_args.get('spark_packages')}"] if app_args.get('spark_packages') else [f"--packages={package_str}"]
+            jar = [f"--jars={app_args.get('spark_jars')}"] if app_args.get('spark_jars') else [f"--jars={eu.JARS}"]
+        else:
+            pac = []
+            jar = []
         med = ["--driver-memory={}".format(app_args['driver-memory'])] if app_args.get('driver-memory') else []
         cod = ["--driver-cores={}".format(app_args['driver-cores'])] if app_args.get('driver-cores') else []
         mee = ["--executor-memory={}".format(app_args['executor-memory'])] if app_args.get('executor-memory') else []
@@ -527,7 +533,7 @@ class DeployPySparkScriptOnAws(object):
         sql = ["--sql_file={}".format(eu.CLUSTER_APP_FOLDER + app_args['sql_file'])] if app_args.get('sql_file') else []
         nam = ["--job_name={}".format(app_args['job_name'])] if app_args.get('job_name') else []
 
-        return spark_submit_args + med + cod + mee + coe + spark_app_args + jop + dep + box + sql + nam
+        return spark_submit_args + pac + jar + med + cod + mee + coe + spark_app_args + jop + dep + box + sql + nam
 
     def run_aws_data_pipeline(self):
         self.s3_ops(self.session)

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -47,7 +47,7 @@ PACKAGES_EMR = ['com.databricks:spark-redshift_2.11:2.0.1', 'org.apache.spark:sp
 PACKAGES_EMR_ALT = ['io.github.spark-redshift-community:spark-redshift_2.12:5.0.3', 'org.apache.spark:spark-avro_2.12:3.1.1', 'mysql:mysql-connector-java:8.0.22', 'org.postgresql:postgresql:42.2.18']  # same but compatible with spark 3.
 PACKAGES_LOCAL = PACKAGES_EMR + ['com.amazonaws:aws-java-sdk-pom:1.11.760', 'org.apache.hadoop:hadoop-aws:2.7.0']
 PACKAGES_LOCAL_ALT = PACKAGES_EMR_ALT + ['com.amazonaws:aws-java-sdk-pom:1.11.760', 'org.apache.hadoop:hadoop-aws:2.7.0']  # will probably need to be moved to hadoop-aws:3.2.1 to work locally.
-JARS = 'https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.13/redshift-jdbc42-2.1.0.13.zip'  # putting here libs not available in public repo so not add-eable to "packages" var. TODO: redshift-jdbc42-2.1.0.13.zip found online so check if add-eable to "packages" 
+JARS = 'https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.13/redshift-jdbc42-2.1.0.13.zip'  # putting here libs not available in public repo so not add-eable to "packages" var. TODO: redshift-jdbc42-2.1.0.13.zip found online so check if add-eable to "packages"
 
 
 class ETL_Base(object):

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -47,7 +47,8 @@ PACKAGES_EMR = ['com.databricks:spark-redshift_2.11:2.0.1', 'org.apache.spark:sp
 PACKAGES_EMR_ALT = ['io.github.spark-redshift-community:spark-redshift_2.12:5.0.3', 'org.apache.spark:spark-avro_2.12:3.1.1', 'mysql:mysql-connector-java:8.0.22', 'org.postgresql:postgresql:42.2.18']  # same but compatible with spark 3.
 PACKAGES_LOCAL = PACKAGES_EMR + ['com.amazonaws:aws-java-sdk-pom:1.11.760', 'org.apache.hadoop:hadoop-aws:2.7.0']
 PACKAGES_LOCAL_ALT = PACKAGES_EMR_ALT + ['com.amazonaws:aws-java-sdk-pom:1.11.760', 'org.apache.hadoop:hadoop-aws:2.7.0']  # will probably need to be moved to hadoop-aws:3.2.1 to work locally.
-JARS = 'https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/1.2.41.1065/RedshiftJDBC42-no-awssdk-1.2.41.1065.jar'  # not available in public repo so cannot be put in "packages" var.
+#JARS = 'https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/1.2.41.1065/RedshiftJDBC42-no-awssdk-1.2.41.1065.jar'  # not available in public repo so cannot be put in "packages" var.
+JARS = 'https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.13/redshift-jdbc42-2.1.0.13.zip'  # putting here libs not available in public repo so not add-eable to "packages" var. TODO: redshift-jdbc42-2.1.0.13.zip found online so check if add-eable to "packages" 
 
 
 class ETL_Base(object):
@@ -1071,9 +1072,12 @@ class Runner():
             # JARs
             package = PACKAGES_LOCAL if jargs.merged_args.get('spark_version', '2.4') == '2.4' else PACKAGES_LOCAL_ALT
             package_str = ','.join(package)
+            package_str = jargs.merged_args.get('spark_packages') or package_str
+            jars_str = jargs.merged_args.get('spark_jars') or JARS
+
             conf = conf \
                 .set("spark.jars.packages", package_str) \
-                .set("spark.jars", JARS)
+                .set("spark.jars", jars_str)
             # Setup above not needed when running from EMR where setup done in spark-submit.
 
         if jargs.merged_args.get('emr_core_instances') == 0:

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -47,7 +47,6 @@ PACKAGES_EMR = ['com.databricks:spark-redshift_2.11:2.0.1', 'org.apache.spark:sp
 PACKAGES_EMR_ALT = ['io.github.spark-redshift-community:spark-redshift_2.12:5.0.3', 'org.apache.spark:spark-avro_2.12:3.1.1', 'mysql:mysql-connector-java:8.0.22', 'org.postgresql:postgresql:42.2.18']  # same but compatible with spark 3.
 PACKAGES_LOCAL = PACKAGES_EMR + ['com.amazonaws:aws-java-sdk-pom:1.11.760', 'org.apache.hadoop:hadoop-aws:2.7.0']
 PACKAGES_LOCAL_ALT = PACKAGES_EMR_ALT + ['com.amazonaws:aws-java-sdk-pom:1.11.760', 'org.apache.hadoop:hadoop-aws:2.7.0']  # will probably need to be moved to hadoop-aws:3.2.1 to work locally.
-#JARS = 'https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/1.2.41.1065/RedshiftJDBC42-no-awssdk-1.2.41.1065.jar'  # not available in public repo so cannot be put in "packages" var.
 JARS = 'https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.13/redshift-jdbc42-2.1.0.13.zip'  # putting here libs not available in public repo so not add-eable to "packages" var. TODO: redshift-jdbc42-2.1.0.13.zip found online so check if add-eable to "packages" 
 
 

--- a/yaetos/scripts/copy/Dockerfile_external
+++ b/yaetos/scripts/copy/Dockerfile_external
@@ -9,7 +9,7 @@ RUN apt update \
 # 2 lines above for jupyterlab
 
 RUN python -m pip install --upgrade pip
-RUN pip3 install --no-deps yaetos==0.9.28
+RUN pip3 install --no-deps yaetos==0.9.29
 # Force latest version to avoid using previous ones.
 RUN pip3 install -r /opt/bitnami/python/lib/python3.8/site-packages/yaetos/scripts/requirements_base.txt
 # Installing libraries required by Yaetos and more. Using this since requirements_base.txt has exact versions.


### PR DESCRIPTION
Updates:
 * made load_connectors work in AWS, was ignore before.
 * allowed users to overwrite jars and package params 
 * updated version of redshift jar since previous was obsolete

Version moved to 0.9.29