### PR TITLE
Update to emr-6.15.0

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7.16  # same as in emr-6.15.0
+        python-version: 3.7  # installs 3.7.17. emr-6.15.0 includes python 3.7.16
     # Spark setup as per https://github.com/marketplace/actions/setup-apache-spark
     - uses: actions/setup-java@v1
       with:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.7.16  # same as in emr-6.15.0
     # Spark setup as per https://github.com/marketplace/actions/setup-apache-spark
     - uses: actions/setup-java@v1
       with:

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -301,7 +301,7 @@ common_params:
     connection_file:  conf/connections.cfg
     redshift_s3_tmp_dir: s3a://dev-spark/tmp_spark/
     email_cred_section: some_email_cred_section  # Section from "connection_file"
-    spark_version: '3.0' # options: '2.4' 'or '3.0'
+    spark_version: '3.4' # options: '2.4', '3.0' or '3.4'
   mode_specific_params:
     prod_EMR:
       root_path: s3://mylake-prod  # don't add '/' at the end

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -70,7 +70,7 @@ class DeployPySparkScriptOnAws(object):
         self.package_path = self.job_log_path + '/code_package'   # format: yaetos/logs/some_job.some_user.20181204.153429/package
         self.package_path_with_bucket = self.job_log_path_with_bucket + '/code_package'   # format: bucket-tempo/yaetos/logs/some_job.some_user.20181204.153429/package
 
-        spark_version = self.deploy_args.get('spark_version', '2.4')
+        spark_version = self.deploy_args.get('spark_version', '3.0')
         if spark_version == '2.4':
             self.emr_version = "emr-5.26.0"
             # used "emr-5.26.0" successfully for a bit. emr-6.0.0 is latest as of june 2020, first with python3 by default but not supported by AWS Data Pipeline, emr-5.26.0 is latest as of aug 2019 # Was "emr-5.8.0", which was compatible with m3.2xlarge.
@@ -79,6 +79,8 @@ class DeployPySparkScriptOnAws(object):
             self.emr_version = "emr-6.1.1"
             # latest is "emr-6.3.0" but latest compatible with AWS Data Piupeline is "emr-6.1.0".
             # see latest supported emr version by AWS Data Pipeline at https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-emrcluster.html
+        elif spark_version == '3.4':
+            self.emr_version = "emr-6.15.0"  # not compatible with "AWS Data Pipeline" but should be with Airflow. Inc Python 3.7.16
 
         if self.deploy_args.get('monitor_git', False):  # TODO: centralize monitor_git
             try:

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -69,7 +69,6 @@ class DeployPySparkScriptOnAws(object):
         self.job_log_path_with_bucket = '{}/{}'.format(self.s3_bucket_logs, self.job_log_path)   # format: bucket-tempo/yaetos/logs/some_job.some_user.20181204.153429
         self.package_path = self.job_log_path + '/code_package'   # format: yaetos/logs/some_job.some_user.20181204.153429/package
         self.package_path_with_bucket = self.job_log_path_with_bucket + '/code_package'   # format: bucket-tempo/yaetos/logs/some_job.some_user.20181204.153429/package
-        # self.s3_dags = CPt(app_args['s3_dags'])
 
         spark_version = self.deploy_args.get('spark_version', '2.4')
         if spark_version == '2.4':
@@ -725,7 +724,6 @@ class DeployPySparkScriptOnAws(object):
         }
 
         param_extras = {key: self.deploy_args[key] for key in self.deploy_args if key.startswith('airflow.')}
-        # import ipdb; ipdb.set_trace()
 
         content = get_template(params, param_extras)
         if not os.path.isdir(self.DAGS):

--- a/yaetos/scripts/requirements_base.txt
+++ b/yaetos/scripts/requirements_base.txt
@@ -11,7 +11,7 @@ networkx==2.4
 duckdb==0.4.0
 
 # libs required for some functionalities but not required in import statements
-pyarrow==9.0.0  # necessary for saving pandas to parquet.
+pyarrow==12.0.1  # necessary for saving pandas to parquet.
 openpyxl==3.0.9  # used to open excel files. TODO: put in a new requirement_extra.txt, since optional.
 pymysql==0.9.3
 psycopg2-binary==2.8.5   # necesary for sqlalchemy-redshift, psycopg2==2.8.5 install fails.

--- a/yaetos/scripts/requirements_base_alt.txt
+++ b/yaetos/scripts/requirements_base_alt.txt
@@ -13,7 +13,7 @@ networkx==2.4
 
 
 # libs required for some functionalities but not required in import statements
-pyarrow==9.0.0  # necessary for saving pandas to parquet.
+pyarrow  # necessary for saving pandas to parquet.
 openpyxl==3.0.9  # used to open excel files. TODO: put in a new requirement_extra.txt, since optional.
 pymysql==0.9.3
 psycopg2-binary==2.8.5   # necesary for sqlalchemy-redshift, psycopg2==2.8.5 install fails.


### PR DESCRIPTION
Update emr version to emr-6.15.0
Involves bumping to python 3.7.16 (still old and about to be deprecated). New EMR to be released soon to move to python 3.8 (required to update pyarrow to a safe version).
Tested to work in EMR and in airflow