### PR TITLE
Executing Scala/Jar jobs

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,7 @@ jobs:
     #   image: docker://manifoldai/orbyter-ml-dev:2.0 # replace name
     # Setup below close to EMR7.0.0 (same python, same spark versions)
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -5,8 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
-    # runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest  # works with "ubuntu-22.04" at least.
     # TODO: try using container (ex below) to have setup consistent with local.
     # ex at https://github.community/t/cant-set-pythonpath-appropriately-for-pytest-in-github-actions/116931/5
     # container:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -5,7 +5,8 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # TODO: try using container (ex below) to have setup consistent with local.
     # ex at https://github.community/t/cant-set-pythonpath-appropriately-for-pytest-in-github-actions/116931/5
     # container:
@@ -35,7 +36,7 @@ jobs:
         pip install -r yaetos/scripts/requirements_base.txt
     - name: Test with pytest
       run: |
-        pip install pytest
+        pip install pytest==7.4.4
         pytest --ignore=yaetos/scripts/
         # TODO: change pytest cmdline above to "pytest tests/ --extraargs?" and find if extraargs exists that gets test running from work dir (i.e. not changing to 'tests/')
     - name: Lint with flake8

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -5,8 +5,8 @@ on: [push]
 jobs:
   build:
 
-    # runs-on: ubuntu-latest
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    # runs-on: ubuntu-22.04
     # TODO: try using container (ex below) to have setup consistent with local.
     # ex at https://github.community/t/cant-set-pythonpath-appropriately-for-pytest-in-github-actions/116931/5
     # container:
@@ -36,7 +36,7 @@ jobs:
         pip install -r yaetos/scripts/requirements_base.txt
     - name: Test with pytest
       run: |
-        pip install pytest==7.4.4
+        pip install pytest==7.4.4  # pb with 8.0.0
         pytest --ignore=yaetos/scripts/
         # TODO: change pytest cmdline above to "pytest tests/ --extraargs?" and find if extraargs exists that gets test running from work dir (i.e. not changing to 'tests/')
     - name: Lint with flake8

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -264,10 +264,12 @@ jobs:
   examples/run_scala_job:
     description: "Sample spark scala code (compiled into a jar), executed through spark-submit"
     jar_job: 'jobs/examples/ex12_scala_job/target/spark_scala_job_2.13-1.0.jar'
-    scala_job: 'jobs/examples/ex12_scala_job/src/spark_scala_job.scala'
-    sbt: 'jobs/examples/ex12_scala_job/build.sbt'
+    scala_job: 'jobs/examples/ex12_scala_job/src/spark_scala_job.scala'  # for ref, compilation to be done manually
+    sbt: 'jobs/examples/ex12_scala_job/build.sbt'  # for ref, compilation to be done manually
     spark_submit_args: '--verbose'
-    spark_app_args: 'jobs/examples/ex12_scala_job/some_text.txt'
+    # spark_app_args: 'jobs/examples/ex12_scala_job/some_text.txt'
+    spark_app_args: '{base_path}/wordcount_example/input/sample_text.txt'
+    load_connectors: none
   
   # wordcount_raw_job: #Job exists but doesn't rely on jobs_metadata entries
 

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -264,6 +264,8 @@ jobs:
   examples/run_scala_job:
     description: "shows a job running scala code (compiled into a jar), through a spark-submit"
     jar_job: 'jobs/examples/ex12_scala_job/target/spark_scala_job_2.13-1.0.jar'
+    scala_job: 'jobs/examples/ex12_scala_job/src/spark_scala_job.scala'
+    sbt: 'jobs/examples/ex12_scala_job/build.sbt'
     spark_submit_args: '--verbose'
     spark_app_args': 'jobs/examples/ex12_scala_job/some_text.txt'
   

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -262,9 +262,11 @@ jobs:
       - examples/ex7_pandas_job.py
 
   examples/run_scala_job:
-    description: "shows a job running scala code (compiled into a jar)."
-    jar_job: 'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar'
-
+    description: "shows a job running scala code (compiled into a jar), through a spark-submit"
+    jar_job: 'jobs/examples/ex12_scala_job/target/spark_scala_job_2.13-1.0.jar'
+    spark_submit_args: '--verbose'
+    spark_app_args': 'jobs/examples/ex12_scala_job/some_text.txt'
+  
   # wordcount_raw_job: #Job exists but doesn't rely on jobs_metadata entries
 
   # ----- Marketing Jobs --------

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -261,6 +261,10 @@ jobs:
       - examples/ex1_sql_job.sql
       - examples/ex7_pandas_job.py
 
+  examples/run_scala_job:
+    description: "shows a job running scala code (compiled into a jar)."
+    jar_job: 'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar'
+
   # wordcount_raw_job: #Job exists but doesn't rely on jobs_metadata entries
 
   # ----- Marketing Jobs --------

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -253,7 +253,7 @@ jobs:
     emails: ['some_email@address.com']
 
   examples/run_jobs:
-    description: "shows a job meant to run a bunch of dependencies (dummy job). Takes no input. Generates no output."
+    description: "shows a job meant to run several dependencies at once. The job itself takes no input and generates no output."
     py_job: 'jobs/generic/dummy_job.py'
     spark_boot: False
     dependencies: 
@@ -262,7 +262,7 @@ jobs:
       - examples/ex7_pandas_job.py
 
   examples/run_scala_job:
-    description: "shows a job running scala code (compiled into a jar), through a spark-submit"
+    description: "Sample spark scala code (compiled into a jar), executed through spark-submit"
     jar_job: 'jobs/examples/ex12_scala_job/target/spark_scala_job_2.13-1.0.jar'
     scala_job: 'jobs/examples/ex12_scala_job/src/spark_scala_job.scala'
     sbt: 'jobs/examples/ex12_scala_job/build.sbt'

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -267,7 +267,7 @@ jobs:
     scala_job: 'jobs/examples/ex12_scala_job/src/spark_scala_job.scala'
     sbt: 'jobs/examples/ex12_scala_job/build.sbt'
     spark_submit_args: '--verbose'
-    spark_app_args': 'jobs/examples/ex12_scala_job/some_text.txt'
+    spark_app_args: 'jobs/examples/ex12_scala_job/some_text.txt'
   
   # wordcount_raw_job: #Job exists but doesn't rely on jobs_metadata entries
 

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -267,7 +267,6 @@ jobs:
     scala_job: 'jobs/examples/ex12_scala_job/src/spark_scala_job.scala'  # for ref, compilation to be done manually
     sbt: 'jobs/examples/ex12_scala_job/build.sbt'  # for ref, compilation to be done manually
     spark_submit_args: '--verbose'
-    # spark_app_args: 'jobs/examples/ex12_scala_job/some_text.txt'
     spark_app_args: '{base_path}/wordcount_example/input/sample_text.txt'
     load_connectors: none
   

--- a/data/wordcount_example/input/sample_text.txt
+++ b/data/wordcount_example/input/sample_text.txt
@@ -1,6 +1,5 @@
-Here is some text, for testing. text. text.
+Here is some sample text, for testing...
 on several
 lines...
-asdf
 ..
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/data/wordcount_example/input/sample_text.txt
+++ b/data/wordcount_example/input/sample_text.txt
@@ -1,1 +1,6 @@
+Here is some text, for testing. text. text.
+on several
+lines...
+asdf
+..
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/yaetos/deploy_test.py
+++ b/tests/yaetos/deploy_test.py
@@ -50,16 +50,14 @@ class Test_DeployPySparkScriptOnAws(object):
         # TODO: other test for 'lib'
 
     def test_get_spark_submit_args(self, app_args):
-        app_args['code_source'] = 'repo'
         app_args['mode'] = 'mode_x'
-        app_file = 'asdf.py'
-        # dep = Dep(deploy_args, app_args)
+        app_file = 'some_file.py'
         actual = Dep.get_spark_submit_args(app_file, app_args)
         expected = [
             'spark-submit',
             '--verbose',
             '--py-files=/home/hadoop/app/scripts.zip',
-            '/home/hadoop/app/asdf.py',
+            '/home/hadoop/app/some_file.py',
             '--mode=mode_x',
             '--deploy=none',
             '--storage=s3',

--- a/tests/yaetos/deploy_test.py
+++ b/tests/yaetos/deploy_test.py
@@ -95,3 +95,18 @@ class Test_DeployPySparkScriptOnAws(object):
         actual = Dep.get_spark_submit_args2(app_file, app_args)
         expected.insert(8, '--sql_file=/home/hadoop/app/some_file.sql')
         assert actual == expected
+
+    def test_get_spark_submit_args_jar(self):
+        app_args = {
+            'jar_job': 'some/job.jar',
+            'spark_app_args': 'some_arg',
+            }
+        app_file = app_args['jar_job']
+        actual = Dep.get_spark_submit_args2(app_file, app_args)
+        expected = [
+            'spark-submit',
+            '--verbose',
+            '/home/hadoop/app/some/job.jar',
+            'some_arg',
+            ]
+        assert actual == expected

--- a/tests/yaetos/deploy_test.py
+++ b/tests/yaetos/deploy_test.py
@@ -49,23 +49,6 @@ class Test_DeployPySparkScriptOnAws(object):
         assert actual == expected
         # TODO: other test for 'lib'
 
-    # def test_get_spark_submit_args(self, app_args):
-    #     app_args['mode'] = 'mode_x'
-    #     app_file = 'some_file.py'
-    #     actual = Dep.get_spark_submit_args(app_file, app_args)
-    #     expected = [
-    #         'spark-submit',
-    #         '--verbose',
-    #         '--py-files=/home/hadoop/app/scripts.zip',
-    #         '/home/hadoop/app/some_file.py',
-    #         '--mode=mode_x',
-    #         '--deploy=none',
-    #         '--storage=s3',
-    #         '--rerun_criteria=None',
-    #         '--job_name=some_job_name',
-    #         ]
-    #     assert actual == expected
-
     def test_get_spark_submit_args(self, app_args):
         # Test base case
         app_args['mode'] = 'mode_x'

--- a/tests/yaetos/deploy_test.py
+++ b/tests/yaetos/deploy_test.py
@@ -65,3 +65,33 @@ class Test_DeployPySparkScriptOnAws(object):
             '--job_name=some_job_name',
             ]
         assert actual == expected
+
+    def test_get_spark_submit_args2(self, app_args):
+        # Test base case
+        app_args['mode'] = 'mode_x'
+        app_file = 'some_file.py'
+        actual = Dep.get_spark_submit_args2(app_file, app_args)
+        expected = [
+            'spark-submit',
+            '--verbose',
+            '--py-files=/home/hadoop/app/scripts.zip',
+            '/home/hadoop/app/some_file.py',
+            '--mode=mode_x',
+            '--deploy=none',
+            '--storage=s3',
+            '--job_name=some_job_name',
+            ]
+        assert actual == expected
+
+        # Test adding args
+        app_args['dependencies'] = True
+        app_args['chain_dependencies'] = True
+        actual = Dep.get_spark_submit_args2(app_file, app_args)
+        expected.insert(4, ' --dependencies --chain_dependencies')
+        assert actual == expected
+
+        # Test adding args
+        app_args['sql_file'] = 'some_file.sql'
+        actual = Dep.get_spark_submit_args2(app_file, app_args)
+        expected.insert(8, '--sql_file=/home/hadoop/app/some_file.sql')
+        assert actual == expected

--- a/tests/yaetos/deploy_test.py
+++ b/tests/yaetos/deploy_test.py
@@ -49,28 +49,28 @@ class Test_DeployPySparkScriptOnAws(object):
         assert actual == expected
         # TODO: other test for 'lib'
 
-    def test_get_spark_submit_args(self, app_args):
-        app_args['mode'] = 'mode_x'
-        app_file = 'some_file.py'
-        actual = Dep.get_spark_submit_args(app_file, app_args)
-        expected = [
-            'spark-submit',
-            '--verbose',
-            '--py-files=/home/hadoop/app/scripts.zip',
-            '/home/hadoop/app/some_file.py',
-            '--mode=mode_x',
-            '--deploy=none',
-            '--storage=s3',
-            '--rerun_criteria=None',
-            '--job_name=some_job_name',
-            ]
-        assert actual == expected
+    # def test_get_spark_submit_args(self, app_args):
+    #     app_args['mode'] = 'mode_x'
+    #     app_file = 'some_file.py'
+    #     actual = Dep.get_spark_submit_args(app_file, app_args)
+    #     expected = [
+    #         'spark-submit',
+    #         '--verbose',
+    #         '--py-files=/home/hadoop/app/scripts.zip',
+    #         '/home/hadoop/app/some_file.py',
+    #         '--mode=mode_x',
+    #         '--deploy=none',
+    #         '--storage=s3',
+    #         '--rerun_criteria=None',
+    #         '--job_name=some_job_name',
+    #         ]
+    #     assert actual == expected
 
-    def test_get_spark_submit_args2(self, app_args):
+    def test_get_spark_submit_args(self, app_args):
         # Test base case
         app_args['mode'] = 'mode_x'
         app_file = 'some_file.py'
-        actual = Dep.get_spark_submit_args2(app_file, app_args)
+        actual = Dep.get_spark_submit_args(app_file, app_args)
         expected = [
             'spark-submit',
             '--verbose',
@@ -86,13 +86,13 @@ class Test_DeployPySparkScriptOnAws(object):
         # Test adding args
         app_args['dependencies'] = True
         app_args['chain_dependencies'] = True
-        actual = Dep.get_spark_submit_args2(app_file, app_args)
+        actual = Dep.get_spark_submit_args(app_file, app_args)
         expected.insert(4, ' --dependencies --chain_dependencies')
         assert actual == expected
 
         # Test adding args
         app_args['sql_file'] = 'some_file.sql'
-        actual = Dep.get_spark_submit_args2(app_file, app_args)
+        actual = Dep.get_spark_submit_args(app_file, app_args)
         expected.insert(8, '--sql_file=/home/hadoop/app/some_file.sql')
         assert actual == expected
 
@@ -102,7 +102,7 @@ class Test_DeployPySparkScriptOnAws(object):
             'spark_app_args': 'some_arg',
             }
         app_file = app_args['jar_job']
-        actual = Dep.get_spark_submit_args2(app_file, app_args)
+        actual = Dep.get_spark_submit_args(app_file, app_args)
         expected = [
             'spark-submit',
             '--verbose',

--- a/tests/yaetos/deploy_test.py
+++ b/tests/yaetos/deploy_test.py
@@ -62,8 +62,7 @@ class Test_DeployPySparkScriptOnAws(object):
             '--mode=mode_x',
             '--deploy=none',
             '--storage=s3',
-            '--job_name=some_job_name',
-            ]
+            '--job_name=some_job_name']
         assert actual == expected
 
         # Test adding args
@@ -82,14 +81,12 @@ class Test_DeployPySparkScriptOnAws(object):
     def test_get_spark_submit_args_jar(self):
         app_args = {
             'jar_job': 'some/job.jar',
-            'spark_app_args': 'some_arg',
-            }
+            'spark_app_args': 'some_arg'}
         app_file = app_args['jar_job']
         actual = Dep.get_spark_submit_args(app_file, app_args)
         expected = [
             'spark-submit',
             '--verbose',
             '/home/hadoop/app/some/job.jar',
-            'some_arg',
-            ]
+            'some_arg']
         assert actual == expected

--- a/tests/yaetos/deploy_test.py
+++ b/tests/yaetos/deploy_test.py
@@ -48,3 +48,22 @@ class Test_DeployPySparkScriptOnAws(object):
         expected = Pt('some/path/')
         assert actual == expected
         # TODO: other test for 'lib'
+
+    def test_get_spark_submit_args(self, app_args):
+        app_args['code_source'] = 'repo'
+        app_args['mode'] = 'mode_x'
+        app_file = 'asdf.py'
+        # dep = Dep(deploy_args, app_args)
+        actual = Dep.get_spark_submit_args(app_file, app_args)
+        expected = [
+            'spark-submit',
+            '--verbose',
+            '--py-files=/home/hadoop/app/scripts.zip',
+            '/home/hadoop/app/asdf.py',
+            '--mode=mode_x',
+            '--deploy=none',
+            '--storage=s3',
+            '--rerun_criteria=None',
+            '--job_name=some_job_name',
+            ]
+        assert actual == expected

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -188,30 +188,34 @@ class Test_Runner(object):
         assert cmd_lst_real == cmd_lst_expected
         # ##### TODO: Runner(Job, **cmd_args).launch_run_mode_spark_submit(self, job)
 
-    # def test_create_spark_submit_jar_job(self):
-    #     """Ex: python jobs/generic/launcher.py \
-    #         --spark_submit_args='verbose' \
-    #         --spark_app_args='mode--storage--job_param_file' \
-    #         --verbose='no value'
-    #     """
-    #     cmd_args = {
-    #         'job_name': 'examples/run_scala_job',
-    #         'jar_job': 'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
-    #         'job_param_file': JOBS_METADATA_FILE,
-    #         'mode': 'dev_local',
-    #         'deploy': 'asdf',
-    #         'spark_submit_args': 'verbose',
-    #         'spark_app_args': '',
-    #         'verbose': 'no value',
-    #     }
-    #     launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args={}, cmd_args=cmd_args, loaded_inputs={})
-    #     cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
-    #     cmd_lst_expected = ['spark-submit',
-    #         '--verbose',
-    #         'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
-    #         ]
-    #     assert cmd_lst_real==cmd_lst_expected
-    #     ##### TODO: works but need to make it work with compiling (to not have jar in git) and with param to run the job from spark-submit
+    def test_create_spark_submit_jar_job(self):
+        """Ex: python jobs/generic/launcher.py \
+            --job_name='examples/run_scala_job' \
+            --jar_job='jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar' \
+            --deploy=local_spark_submit \
+            --spark_submit_keys='verbose' \
+            --spark_app_args='jobs/examples/scala_test5/some_text.txt' \
+            --verbose='no value' \
+            --dry_run=True 
+        """
+        job_args = {
+            'job_name': 'examples/run_scala_job',
+            'jar_job': 'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
+            'job_param_file': JOBS_METADATA_FILE,
+            'mode': 'dev_local',
+            'deploy': 'asdf',
+            'spark_submit_keys': 'verbose',
+            'spark_app_keys': '',
+            'verbose': 'no value',
+        }
+        launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args=job_args, cmd_args={}, loaded_inputs={})
+        cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
+        cmd_lst_expected = ['spark-submit',
+            '--verbose',
+            'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
+            ]
+        assert cmd_lst_real==cmd_lst_expected
+        # ##### TODO: works but need to make it work with compiling (to not have jar in git) and with param to run the job from spark-submit
 
 
 class Test_Flow(object):

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -150,12 +150,9 @@ class Test_Runner(object):
                 'some_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
                 'other_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
             },
-            'output': {'path':'n/a', 'type':'csv', 'df_type':'pandas'},  # TODO: remove need for some of the params.
-            'spark_boot': False,
-        }
-
+            'output': {'path':'n/a', 'type':'None', 'df_type':'pandas'},  # i.e. there is an output but it won't be dumped to disk.
+            'spark_boot': False,}
         job_post = Runner(Job, **cmd_args).run()  # will run the full job based on small scale data, to test full job scope.
-        print(job_post.jargs.merged_args)
         assert hasattr(job_post, 'out_df')
 
     def test_create_spark_submit_python_job(self):

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -191,28 +191,29 @@ class Test_Runner(object):
     def test_create_spark_submit_jar_job(self):
         """Ex: python jobs/generic/launcher.py \
             --job_name='examples/run_scala_job' \
+            --job_param_file='conf/jobs_metadata.yml' \
             --jar_job='jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar' \
             --deploy=local_spark_submit \
-            --spark_submit_keys='verbose' \
+            --spark_submit_args='--verbose' \
             --spark_app_args='jobs/examples/scala_test5/some_text.txt' \
-            --verbose='no value' \
             --dry_run=True 
         """
         job_args = {
             'job_name': 'examples/run_scala_job',
-            'jar_job': 'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
             'job_param_file': JOBS_METADATA_FILE,
+            'jar_job': 'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
+            'deploy': 'asdf',  # required but not used here.
             'mode': 'dev_local',
-            'deploy': 'asdf',
-            'spark_submit_keys': 'verbose',
-            'spark_app_keys': '',
-            'verbose': 'no value',
+            'spark_submit_args': '--verbose',
+            'spark_app_args': 'jobs/examples/scala_test5/some_text.txt',
         }
         launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args=job_args, cmd_args={}, loaded_inputs={})
         cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
-        cmd_lst_expected = ['spark-submit',
+        cmd_lst_expected = [
+            'spark-submit',
             '--verbose',
             'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
+            'jobs/examples/scala_test5/some_text.txt',
             ]
         assert cmd_lst_real==cmd_lst_expected
         # ##### TODO: works but need to make it work with compiling (to not have jar in git) and with param to run the job from spark-submit

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -142,8 +142,6 @@ class Test_Runner(object):
     def test_run(self):
         from jobs.examples.ex7_pandas_job import Job
         cmd_args = {
-            # 'job_name': 'examples/ex7_pandas_job.py',
-            # 'job_param_file': JOBS_METADATA_FILE,
             'job_param_file': None,
             'deploy': 'none',
             'dependencies': False,
@@ -155,12 +153,9 @@ class Test_Runner(object):
             'spark_boot': False,
         }
 
-        # Job = ETL_Base
         job_post = Runner(Job, **cmd_args).run()  # will run the full job based on small scale data, to test full job scope.
-        # print(job_post.out_df)
         print(job_post.jargs.merged_args)
         assert hasattr(job_post, 'out_df')
-        # assert False
 
     def test_create_spark_submit_python_job(self):
         """Ex: python jobs/generic/launcher.py \

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -142,9 +142,10 @@ class Test_Job_Args_Parser(object):
 class Test_Runner(object):
     def test_run(self):
         from jobs.examples.ex7_pandas_job import Job
-        cmd_args = {
+        job_args = {
             'job_param_file': None,
             'deploy': 'none',
+            # 'py_code': 'asdf.py',
             'dependencies': False,
             'inputs': {
                 'some_events': {'path': "./tests/fixtures/data_sample/wiki_example/input/", 'type': 'csv', 'df_type': 'pandas'},
@@ -152,7 +153,7 @@ class Test_Runner(object):
             },
             'output': {'path': 'n/a', 'type': 'None', 'df_type': 'pandas'},  # i.e. there is an output but it won't be dumped to disk.
             'spark_boot': False}
-        job_post = Runner(Job, **cmd_args).run()  # will run the full job based on small scale data, to test full job scope.
+        job_post = Runner(Job, **job_args).run()  # will run the full job based on small scale data, to test full job scope.
         assert hasattr(job_post, 'out_df')
 
     def test_create_spark_submit_python_job(self):
@@ -163,17 +164,17 @@ class Test_Runner(object):
             --spark_app_args='mode--storage--job_param_file' \
             --verbose='no value'
         """
-        cmd_args = {
+        job_args = {
             'deploy': 'none',
             'mode': 'dev_local',
             'job_param_file': JOBS_METADATA_FILE,
             'job_name': 'examples/ex7_pandas_job.py',
             'storage': 'local',
-            'spark_submit_args': 'verbose',
-            'spark_app_args': 'mode--storage--job_param_file',
+            'spark_submit_keys': 'verbose',
+            'spark_app_keys': 'mode--storage--job_param_file',
             'verbose': 'no value',
         }
-        launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args={}, cmd_args=cmd_args, loaded_inputs={})
+        launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args=job_args, cmd_args={}, loaded_inputs={})
         cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
         cmd_lst_expected = [
             'spark-submit',

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -182,7 +182,7 @@ class Test_Runner(object):
             '--verbose',
             'jobs/examples/ex12_scala_job/target/spark_scala_job_2.13-1.0.jar',
             'jobs/examples/ex12_scala_job/some_text.txt']
-        assert cmd_lst_real==cmd_lst_expected
+        assert cmd_lst_real == cmd_lst_expected
 
 
 class Test_Flow(object):

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -143,10 +143,11 @@ class Test_Runner(object):
         from jobs.examples.ex7_pandas_job import Job
         cmd_args = {
             # 'job_name': 'examples/ex7_pandas_job.py',
-            'job_param_file': JOBS_METADATA_FILE,
+            # 'job_param_file': JOBS_METADATA_FILE,
+            'job_param_file': None,
             'deploy': 'none',
             'dependencies': False,
-            'input': {
+            'inputs': {
                 'some_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
                 'other_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
             },

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -143,21 +143,17 @@ class Test_Runner(object):
         cmd_args = {
             'job_name': 'examples/ex7_pandas_job.py',
             'deploy': 'none',
-            # 'mode': 'dev_local',
-            # 'job_param_file': JOBS_METADATA_FILE,
             'input': {
                 'some_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
                 'other_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
             },
             'output': {'path':'n/a', 'type':'csv', 'df_type':'pandas'},
-            # 'storage': 'local',
             'spark_boot': False,
         }
         Job = ETL_Base
-        job_post = Runner(Job, **cmd_args).run()
+        job_post = Runner(Job, **cmd_args).run()  # will run the full job based on small scale data, to test full job scope.
         print(job_post.out_df)
         assert hasattr(job_post, 'out_df')
-        # assert False
 
     def test_create_spark_submit_python_job(self):
         """Ex: python jobs/generic/launcher.py \

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -150,7 +150,7 @@ class Test_Runner(object):
             },
             'output': {'path': 'n/a', 'type': 'None', 'df_type': 'pandas'},  # i.e. there is an output but it won't be dumped to disk.
             'spark_boot': False}
-        job_post = Runner(Job, **job_args).run()  # will run the full job based on small scale data, to test full job scope.
+        job_post = Runner(Job, **job_args).run()  # will run the full job based on small scale data
         assert hasattr(job_post, 'out_df')
 
     def test_create_spark_submit_python_job(self):
@@ -159,8 +159,7 @@ class Test_Runner(object):
             'arg1': 'value1',
             'arg2': 'value2',
             'spark_submit_args': '--verbose',
-            'spark_app_keys': 'arg1--arg2',
-        }
+            'spark_app_keys': 'arg1--arg2'}
         launch_jargs = Job_Args_Parser(defaults_args={}, yml_args={}, job_args=job_args, cmd_args={}, build_yml_args=False, loaded_inputs={})
         cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
         cmd_lst_expected = [
@@ -170,25 +169,20 @@ class Test_Runner(object):
             '--arg1=value1',
             '--arg2=value2']
         assert cmd_lst_real == cmd_lst_expected
-        # ##### TODO: Runner(Job, **cmd_args).launch_run_mode_spark_submit(self, job)
 
     def test_create_spark_submit_jar_job(self):
         job_args = {
-            # 'job_param_file': None,
             'jar_job': 'jobs/examples/ex12_scala_job/target/spark_scala_job_2.13-1.0.jar',
             'spark_submit_args': '--verbose',
-            'spark_app_args': 'jobs/examples/ex12_scala_job/some_text.txt',
-        }
+            'spark_app_args': 'jobs/examples/ex12_scala_job/some_text.txt'}
         launch_jargs = Job_Args_Parser(defaults_args={}, yml_args={}, job_args=job_args, cmd_args={}, build_yml_args=False, loaded_inputs={})
         cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
         cmd_lst_expected = [
             'spark-submit',
             '--verbose',
             'jobs/examples/ex12_scala_job/target/spark_scala_job_2.13-1.0.jar',
-            'jobs/examples/ex12_scala_job/some_text.txt',
-            ]
+            'jobs/examples/ex12_scala_job/some_text.txt']
         assert cmd_lst_real==cmd_lst_expected
-        # ##### TODO: works but need to make it work with compiling (to not have jar in git) and with param to run the job from spark-submit
 
 
 class Test_Flow(object):

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 import pytest
 from yaetos.etl_utils import ETL_Base, \
-    Period_Builder, Job_Args_Parser, Job_Yml_Parser, Flow, \
+    Period_Builder, Job_Args_Parser, Job_Yml_Parser, Runner, Flow, \
     get_job_class, LOCAL_JOB_FOLDER, JOBS_METADATA_FILE
 
 
@@ -137,6 +137,36 @@ class Test_Job_Args_Parser(object):
             job.validate()
         except Exception as exc:
             assert False, f"'test_validate_params' raised an exception: {exc}"
+
+class Test_Runner(object):
+    def test_create_spark_submit_python_job(self):
+        """Ex: python jobs/generic/launcher.py \
+            --deploy=local_spark_submit \
+            --job_name=examples/ex0_extraction_job.py \
+            --spark_submit_args='verbose' \
+            --spark_app_args='mode--storage--job_param_file' \
+            --verbose='no value'
+        """
+        cmd_args = {
+            'deploy': 'none',
+            'mode': 'dev_local',
+            'job_param_file': JOBS_METADATA_FILE,
+            'job_name': 'examples/ex0_extraction_job.py',
+            'storage': 'local',
+            'spark_submit_args': 'verbose',
+            'spark_app_args': 'mode--storage--job_param_file',
+            'verbose': 'no value',
+        }
+        launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args={}, cmd_args=cmd_args, loaded_inputs={})
+        cmd_lst_real = Runner.create_spark_submit(app_name='test_app', jargs=launch_jargs)
+        cmd_lst_expected = ['spark-submit',
+            '--verbose',
+            'jobs/examples/ex0_extraction_job.py',
+            '--mode=dev_local',
+            '--storage=local',
+            '--job_param_file=conf/jobs_metadata.yml',
+            ]
+        assert cmd_lst_real==cmd_lst_expected
 
 
 class Test_Flow(object):

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -140,10 +140,12 @@ class Test_Job_Args_Parser(object):
 
 class Test_Runner(object):
     def test_run(self):
+        from jobs.examples.ex7_pandas_job import Job
         cmd_args = {
-            'job_name': 'examples/ex7_pandas_job.py',
+            # 'job_name': 'examples/ex7_pandas_job.py',
             'job_param_file': JOBS_METADATA_FILE,
             'deploy': 'none',
+            'dependencies': False,
             'input': {
                 'some_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
                 'other_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
@@ -151,10 +153,13 @@ class Test_Runner(object):
             'output': {'path':'n/a', 'type':'csv', 'df_type':'pandas'},  # TODO: remove need for some of the params.
             'spark_boot': False,
         }
-        Job = ETL_Base
+
+        # Job = ETL_Base
         job_post = Runner(Job, **cmd_args).run()  # will run the full job based on small scale data, to test full job scope.
-        print(job_post.out_df)
+        # print(job_post.out_df)
+        print(job_post.jargs.merged_args)
         assert hasattr(job_post, 'out_df')
+        # assert False
 
     def test_create_spark_submit_python_job(self):
         """Ex: python jobs/generic/launcher.py \

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -151,7 +151,7 @@ class Test_Runner(object):
                 'other_events': {'path': "./tests/fixtures/data_sample/wiki_example/input/", 'type': 'csv', 'df_type': 'pandas'},
             },
             'output': {'path': 'n/a', 'type': 'None', 'df_type': 'pandas'},  # i.e. there is an output but it won't be dumped to disk.
-            'spark_boot': False,}
+            'spark_boot': False}
         job_post = Runner(Job, **cmd_args).run()  # will run the full job based on small scale data, to test full job scope.
         assert hasattr(job_post, 'out_df')
 
@@ -181,8 +181,8 @@ class Test_Runner(object):
             'jobs/examples/ex7_pandas_job.py',
             '--mode=dev_local',
             '--storage=local',
-            '--job_param_file=conf/jobs_metadata.yml',]
-        assert cmd_lst_real==cmd_lst_expected
+            '--job_param_file=conf/jobs_metadata.yml']
+        assert cmd_lst_real == cmd_lst_expected
         # ##### TODO: Runner(Job, **cmd_args).launch_run_mode_spark_submit(self, job)
 
     # def test_create_spark_submit_jar_job(self):

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -147,7 +147,7 @@ class Test_Runner(object):
                 'some_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
                 'other_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
             },
-            'output': {'path':'n/a', 'type':'csv', 'df_type':'pandas'},
+            'output': {'path':'n/a', 'type':'csv', 'df_type':'pandas'},  # TODO: remove need for some of the params.
             'spark_boot': False,
         }
         Job = ETL_Base

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -142,6 +142,7 @@ class Test_Runner(object):
     def test_run(self):
         cmd_args = {
             'job_name': 'examples/ex7_pandas_job.py',
+            'job_param_file': JOBS_METADATA_FILE,
             'deploy': 'none',
             'input': {
                 'some_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -147,10 +147,10 @@ class Test_Runner(object):
             'deploy': 'none',
             'dependencies': False,
             'inputs': {
-                'some_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
-                'other_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
+                'some_events': {'path': "./tests/fixtures/data_sample/wiki_example/input/", 'type': 'csv', 'df_type': 'pandas'},
+                'other_events': {'path': "./tests/fixtures/data_sample/wiki_example/input/", 'type': 'csv', 'df_type': 'pandas'},
             },
-            'output': {'path':'n/a', 'type':'None', 'df_type':'pandas'},  # i.e. there is an output but it won't be dumped to disk.
+            'output': {'path': 'n/a', 'type': 'None', 'df_type': 'pandas'},  # i.e. there is an output but it won't be dumped to disk.
             'spark_boot': False,}
         job_post = Runner(Job, **cmd_args).run()  # will run the full job based on small scale data, to test full job scope.
         assert hasattr(job_post, 'out_df')
@@ -175,13 +175,13 @@ class Test_Runner(object):
         }
         launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args={}, cmd_args=cmd_args, loaded_inputs={})
         cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
-        cmd_lst_expected = ['spark-submit',
+        cmd_lst_expected = [
+            'spark-submit',
             '--verbose',
             'jobs/examples/ex7_pandas_job.py',
             '--mode=dev_local',
             '--storage=local',
-            '--job_param_file=conf/jobs_metadata.yml',
-            ]
+            '--job_param_file=conf/jobs_metadata.yml',]
         assert cmd_lst_real==cmd_lst_expected
         ##### TODO: Runner(Job, **cmd_args).launch_run_mode_spark_submit(self, job)
 

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -106,19 +106,19 @@ class Test_Job_Args_Parser(object):
         defaults_args = {'py_job': 'some_job.py', 'mode': 'dev_local', 'deploy': 'code', 'output': {'path': 'n/a', 'type': 'csv'}}
         expected_args = {**{'inputs': {}, 'is_incremental': False}, **defaults_args}
 
-        jargs = Job_Args_Parser(defaults_args=defaults_args, yml_args={}, job_args={}, cmd_args={})
+        jargs = Job_Args_Parser(defaults_args=defaults_args, yml_args={}, job_args={}, cmd_args={}, build_yml_args=False)
         assert jargs.merged_args == expected_args
 
     def test_validate_params(self):
         # Error raised, py_job
         defaults_args = {'py_job': None, 'mode': 'dev_local', 'deploy': 'code', 'output': {'path': 'n/a', 'type': 'csv'}}
-        job = Job_Args_Parser(defaults_args=defaults_args, yml_args={}, job_args={}, cmd_args={}, validate=False)
+        job = Job_Args_Parser(defaults_args=defaults_args, yml_args={}, job_args={}, cmd_args={}, build_yml_args=False, validate=False)
         with pytest.raises(Exception):
             job.validate()
 
         # Error not raised, py_job
         defaults_args['py_job'] = 'some_job.py'
-        job = Job_Args_Parser(defaults_args=defaults_args, yml_args={}, job_args={}, cmd_args={}, validate=False)
+        job = Job_Args_Parser(defaults_args=defaults_args, yml_args={}, job_args={}, cmd_args={}, build_yml_args=False, validate=False)
         try:
             job.validate()
         except Exception as exc:
@@ -126,13 +126,13 @@ class Test_Job_Args_Parser(object):
 
         # Error raised, sql_file
         defaults_args['py_job'] = 'sql_spark_job.py'
-        job = Job_Args_Parser(defaults_args=defaults_args, yml_args={}, job_args={}, cmd_args={}, validate=False)
+        job = Job_Args_Parser(defaults_args=defaults_args, yml_args={}, job_args={}, cmd_args={}, build_yml_args=False, validate=False)
         with pytest.raises(Exception):
             job.validate()
 
         # Error not raised, sql_file
         defaults_args['sql_file'] = 'some_job.sql'
-        job = Job_Args_Parser(defaults_args=defaults_args, yml_args={}, job_args={}, cmd_args={}, validate=False)
+        job = Job_Args_Parser(defaults_args=defaults_args, yml_args={}, job_args={}, cmd_args={}, build_yml_args=False, validate=False)
         try:
             job.validate()
         except Exception as exc:

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -183,7 +183,7 @@ class Test_Runner(object):
             '--storage=local',
             '--job_param_file=conf/jobs_metadata.yml',]
         assert cmd_lst_real==cmd_lst_expected
-        ##### TODO: Runner(Job, **cmd_args).launch_run_mode_spark_submit(self, job)
+        # ##### TODO: Runner(Job, **cmd_args).launch_run_mode_spark_submit(self, job)
 
     # def test_create_spark_submit_jar_job(self):
     #     """Ex: python jobs/generic/launcher.py \

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -157,12 +157,14 @@ class Test_Runner(object):
         assert hasattr(job_post, 'out_df')
 
     def test_create_spark_submit_python_job(self):
-        """Ex: python jobs/generic/launcher.py \
+        """Ex: 
+        python jobs/generic/launcher.py \
             --deploy=local_spark_submit \
             --job_name=examples/ex7_pandas_job.py \
-            --spark_submit_args='verbose' \
-            --spark_app_args='mode--storage--job_param_file' \
-            --verbose='no value'
+            --job_param_file='conf/jobs_metadata.yml' \
+            --spark_submit_keys='verbose' \
+            --spark_app_keys='mode--storage--job_param_file' \
+            --verbose='no value'  # TODO: remove need for 'no value'
         """
         job_args = {
             'deploy': 'none',

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -142,7 +142,7 @@ class Test_Runner(object):
     def test_create_spark_submit_python_job(self):
         """Ex: python jobs/generic/launcher.py \
             --deploy=local_spark_submit \
-            --job_name=examples/ex0_extraction_job.py \
+            --job_name=examples/ex7_pandas_job.py \
             --spark_submit_args='verbose' \
             --spark_app_args='mode--storage--job_param_file' \
             --verbose='no value'
@@ -151,17 +151,17 @@ class Test_Runner(object):
             'deploy': 'none',
             'mode': 'dev_local',
             'job_param_file': JOBS_METADATA_FILE,
-            'job_name': 'examples/ex0_extraction_job.py',
+            'job_name': 'examples/ex7_pandas_job.py',
             'storage': 'local',
             'spark_submit_args': 'verbose',
             'spark_app_args': 'mode--storage--job_param_file',
             'verbose': 'no value',
         }
         launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args={}, cmd_args=cmd_args, loaded_inputs={})
-        cmd_lst_real = Runner.create_spark_submit(app_name='test_app', jargs=launch_jargs)
+        cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
         cmd_lst_expected = ['spark-submit',
             '--verbose',
-            'jobs/examples/ex0_extraction_job.py',
+            'jobs/examples/ex7_pandas_job.py',
             '--mode=dev_local',
             '--storage=local',
             '--job_param_file=conf/jobs_metadata.yml',

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -144,9 +144,6 @@ class Test_Runner(object):
         from jobs.examples.ex7_pandas_job import Job
         job_args = {
             'job_param_file': None,
-            # 'deploy': 'none',
-            # 'py_code': 'asdf.py',
-            # 'dependencies': False,
             'inputs': {
                 'some_events': {'path': "./tests/fixtures/data_sample/wiki_example/input/", 'type': 'csv', 'df_type': 'pandas'},
                 'other_events': {'path': "./tests/fixtures/data_sample/wiki_example/input/", 'type': 'csv', 'df_type': 'pandas'},
@@ -158,12 +155,7 @@ class Test_Runner(object):
 
     def test_create_spark_submit_python_job(self):
         job_args = {
-            # 'deploy': 'none',
-            # 'mode': 'dev_local',
-            # 'job_param_file': JOBS_METADATA_FILE,
             'py_job': 'jobs/examples/ex7_pandas_job.py',
-            # 'job_param_file': None,
-            # 'job_name': 'examples/ex7_pandas_job.py',
             'arg1': 'value1',
             'arg2': 'value2',
             'spark_submit_args': '--verbose',
@@ -182,12 +174,8 @@ class Test_Runner(object):
 
     def test_create_spark_submit_jar_job(self):
         job_args = {
-            # 'job_name': 'examples/run_scala_job',
-            # 'job_param_file': JOBS_METADATA_FILE,
-            'job_param_file': None,
+            # 'job_param_file': None,
             'jar_job': 'jobs/examples/ex12_scala_job/target/spark_scala_job_2.13-1.0.jar',
-            # 'deploy': 'asdf',  # required but not used here.
-            # 'mode': 'dev_local',
             'spark_submit_args': '--verbose',
             'spark_app_args': 'jobs/examples/ex12_scala_job/some_text.txt',
         }
@@ -197,7 +185,7 @@ class Test_Runner(object):
             'spark-submit',
             '--verbose',
             'jobs/examples/ex12_scala_job/target/spark_scala_job_2.13-1.0.jar',
-            'jobs/examples/scala_test5/some_text.txt',
+            'jobs/examples/ex12_scala_job/some_text.txt',
             ]
         assert cmd_lst_real==cmd_lst_expected
         # ##### TODO: works but need to make it work with compiling (to not have jar in git) and with param to run the job from spark-submit

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -139,6 +139,26 @@ class Test_Job_Args_Parser(object):
             assert False, f"'test_validate_params' raised an exception: {exc}"
 
 class Test_Runner(object):
+    def test_run(self):
+        cmd_args = {
+            'job_name': 'examples/ex7_pandas_job.py',
+            'deploy': 'none',
+            # 'mode': 'dev_local',
+            # 'job_param_file': JOBS_METADATA_FILE,
+            'input': {
+                'some_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
+                'other_events': {'path':"./tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'df_type':'pandas'},
+            },
+            'output': {'path':'n/a', 'type':'csv', 'df_type':'pandas'},
+            # 'storage': 'local',
+            'spark_boot': False,
+        }
+        Job = ETL_Base
+        job_post = Runner(Job, **cmd_args).run()
+        print(job_post.out_df)
+        assert hasattr(job_post, 'out_df')
+        # assert False
+
     def test_create_spark_submit_python_job(self):
         """Ex: python jobs/generic/launcher.py \
             --deploy=local_spark_submit \

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -158,13 +158,16 @@ class Test_Runner(object):
             'py_job': 'jobs/examples/ex7_pandas_job.py',
             'arg1': 'value1',
             'arg2': 'value2',
+            'py-files': 'some/files.zip',
             'spark_submit_args': '--verbose',
+            'spark_submit_keys': 'py-files',
             'spark_app_keys': 'arg1--arg2'}
         launch_jargs = Job_Args_Parser(defaults_args={}, yml_args={}, job_args=job_args, cmd_args={}, build_yml_args=False, loaded_inputs={})
         cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
         cmd_lst_expected = [
             'spark-submit',
             '--verbose',
+            '--py-files=some/files.zip',
             'jobs/examples/ex7_pandas_job.py',
             '--arg1=value1',
             '--arg2=value2']

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -167,6 +167,32 @@ class Test_Runner(object):
             '--job_param_file=conf/jobs_metadata.yml',
             ]
         assert cmd_lst_real==cmd_lst_expected
+        ##### TODO: Runner(Job, **cmd_args).launch_run_mode_spark_submit(self, job)
+
+    def test_create_spark_submit_jar_job(self):
+        """Ex: python jobs/generic/launcher.py \
+            --spark_submit_args='verbose' \
+            --spark_app_args='mode--storage--job_param_file' \
+            --verbose='no value'
+        """
+        cmd_args = {
+            'job_name': 'examples/run_scala_job',
+            'jar_job': 'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
+            'job_param_file': JOBS_METADATA_FILE,
+            'mode': 'dev_local',
+            'deploy': 'asdf',
+            'spark_submit_args': 'verbose',
+            'spark_app_args': '',
+            'verbose': 'no value',
+        }
+        launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args={}, cmd_args=cmd_args, loaded_inputs={})
+        cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
+        cmd_lst_expected = ['spark-submit',
+            '--verbose',
+            'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
+            ]
+        assert cmd_lst_real==cmd_lst_expected
+        ##### TODO: works but need to make it work with compiling (to not have jar in git) and with param to run the job from spark-submit
 
 
 class Test_Flow(object):

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -138,6 +138,7 @@ class Test_Job_Args_Parser(object):
         except Exception as exc:
             assert False, f"'test_validate_params' raised an exception: {exc}"
 
+
 class Test_Runner(object):
     def test_run(self):
         from jobs.examples.ex7_pandas_job import Job
@@ -187,30 +188,30 @@ class Test_Runner(object):
         assert cmd_lst_real==cmd_lst_expected
         ##### TODO: Runner(Job, **cmd_args).launch_run_mode_spark_submit(self, job)
 
-    def test_create_spark_submit_jar_job(self):
-        """Ex: python jobs/generic/launcher.py \
-            --spark_submit_args='verbose' \
-            --spark_app_args='mode--storage--job_param_file' \
-            --verbose='no value'
-        """
-        cmd_args = {
-            'job_name': 'examples/run_scala_job',
-            'jar_job': 'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
-            'job_param_file': JOBS_METADATA_FILE,
-            'mode': 'dev_local',
-            'deploy': 'asdf',
-            'spark_submit_args': 'verbose',
-            'spark_app_args': '',
-            'verbose': 'no value',
-        }
-        launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args={}, cmd_args=cmd_args, loaded_inputs={})
-        cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
-        cmd_lst_expected = ['spark-submit',
-            '--verbose',
-            'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
-            ]
-        assert cmd_lst_real==cmd_lst_expected
-        ##### TODO: works but need to make it work with compiling (to not have jar in git) and with param to run the job from spark-submit
+    # def test_create_spark_submit_jar_job(self):
+    #     """Ex: python jobs/generic/launcher.py \
+    #         --spark_submit_args='verbose' \
+    #         --spark_app_args='mode--storage--job_param_file' \
+    #         --verbose='no value'
+    #     """
+    #     cmd_args = {
+    #         'job_name': 'examples/run_scala_job',
+    #         'jar_job': 'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
+    #         'job_param_file': JOBS_METADATA_FILE,
+    #         'mode': 'dev_local',
+    #         'deploy': 'asdf',
+    #         'spark_submit_args': 'verbose',
+    #         'spark_app_args': '',
+    #         'verbose': 'no value',
+    #     }
+    #     launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args={}, cmd_args=cmd_args, loaded_inputs={})
+    #     cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
+    #     cmd_lst_expected = ['spark-submit',
+    #         '--verbose',
+    #         'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
+    #         ]
+    #     assert cmd_lst_real==cmd_lst_expected
+    #     ##### TODO: works but need to make it work with compiling (to not have jar in git) and with param to run the job from spark-submit
 
 
 class Test_Flow(object):

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -144,9 +144,9 @@ class Test_Runner(object):
         from jobs.examples.ex7_pandas_job import Job
         job_args = {
             'job_param_file': None,
-            'deploy': 'none',
+            # 'deploy': 'none',
             # 'py_code': 'asdf.py',
-            'dependencies': False,
+            # 'dependencies': False,
             'inputs': {
                 'some_events': {'path': "./tests/fixtures/data_sample/wiki_example/input/", 'type': 'csv', 'df_type': 'pandas'},
                 'other_events': {'path': "./tests/fixtures/data_sample/wiki_example/input/", 'type': 'csv', 'df_type': 'pandas'},
@@ -157,62 +157,46 @@ class Test_Runner(object):
         assert hasattr(job_post, 'out_df')
 
     def test_create_spark_submit_python_job(self):
-        """Ex: 
-        python jobs/generic/launcher.py \
-            --deploy=local_spark_submit \
-            --job_name=examples/ex7_pandas_job.py \
-            --job_param_file='conf/jobs_metadata.yml' \
-            --spark_submit_keys='verbose' \
-            --spark_app_keys='mode--storage--job_param_file' \
-            --verbose='no value'  # TODO: remove need for 'no value'
-        """
         job_args = {
-            'deploy': 'none',
-            'mode': 'dev_local',
-            'job_param_file': JOBS_METADATA_FILE,
-            'job_name': 'examples/ex7_pandas_job.py',
-            'storage': 'local',
-            'spark_submit_keys': 'verbose',
-            'spark_app_keys': 'mode--storage--job_param_file',
-            'verbose': 'no value',
+            # 'deploy': 'none',
+            # 'mode': 'dev_local',
+            # 'job_param_file': JOBS_METADATA_FILE,
+            'py_job': 'jobs/examples/ex7_pandas_job.py',
+            # 'job_param_file': None,
+            # 'job_name': 'examples/ex7_pandas_job.py',
+            'arg1': 'value1',
+            'arg2': 'value2',
+            'spark_submit_args': '--verbose',
+            'spark_app_keys': 'arg1--arg2',
         }
-        launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args=job_args, cmd_args={}, loaded_inputs={})
+        launch_jargs = Job_Args_Parser(defaults_args={}, yml_args={}, job_args=job_args, cmd_args={}, build_yml_args=False, loaded_inputs={})
         cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
         cmd_lst_expected = [
             'spark-submit',
             '--verbose',
             'jobs/examples/ex7_pandas_job.py',
-            '--mode=dev_local',
-            '--storage=local',
-            '--job_param_file=conf/jobs_metadata.yml']
+            '--arg1=value1',
+            '--arg2=value2']
         assert cmd_lst_real == cmd_lst_expected
         # ##### TODO: Runner(Job, **cmd_args).launch_run_mode_spark_submit(self, job)
 
     def test_create_spark_submit_jar_job(self):
-        """Ex: python jobs/generic/launcher.py \
-            --job_name='examples/run_scala_job' \
-            --job_param_file='conf/jobs_metadata.yml' \
-            --jar_job='jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar' \
-            --deploy=local_spark_submit \
-            --spark_submit_args='--verbose' \
-            --spark_app_args='jobs/examples/scala_test5/some_text.txt' \
-            --dry_run=True 
-        """
         job_args = {
-            'job_name': 'examples/run_scala_job',
-            'job_param_file': JOBS_METADATA_FILE,
-            'jar_job': 'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
-            'deploy': 'asdf',  # required but not used here.
-            'mode': 'dev_local',
+            # 'job_name': 'examples/run_scala_job',
+            # 'job_param_file': JOBS_METADATA_FILE,
+            'job_param_file': None,
+            'jar_job': 'jobs/examples/ex12_scala_job/target/spark_scala_job_2.13-1.0.jar',
+            # 'deploy': 'asdf',  # required but not used here.
+            # 'mode': 'dev_local',
             'spark_submit_args': '--verbose',
-            'spark_app_args': 'jobs/examples/scala_test5/some_text.txt',
+            'spark_app_args': 'jobs/examples/ex12_scala_job/some_text.txt',
         }
-        launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args=job_args, cmd_args={}, loaded_inputs={})
+        launch_jargs = Job_Args_Parser(defaults_args={}, yml_args={}, job_args=job_args, cmd_args={}, build_yml_args=False, loaded_inputs={})
         cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
         cmd_lst_expected = [
             'spark-submit',
             '--verbose',
-            'jobs/examples/scala_test5/target/scala-2.13/spark_scala_test_2.13-1.0.jar',
+            'jobs/examples/ex12_scala_job/target/spark_scala_job_2.13-1.0.jar',
             'jobs/examples/scala_test5/some_text.txt',
             ]
         assert cmd_lst_real==cmd_lst_expected
@@ -228,7 +212,7 @@ class Test_Flow(object):
             'job_name': 'examples/ex4_dependency2_job.py',
             'storage': 'local',
         }
-        launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args={}, cmd_args=cmd_args, loaded_inputs={})
+        launch_jargs = Job_Args_Parser(defaults_args={}, yml_args=None, job_args={}, cmd_args=cmd_args, build_yml_args=True, loaded_inputs={})
         connection_real = Flow.create_connections_jobs(launch_jargs.storage, launch_jargs.merged_args)
         connection_expected = pd.DataFrame(
             columns=['source_job', 'destination_job'],

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -558,14 +558,14 @@ class DeployPySparkScriptOnAws(object):
                 }
 
         overridable_args.update(app_args)
-        args = overridable_args
+        args = overridable_args.copy()
         unoverridable_args = {
             'py-files': f"{eu.CLUSTER_APP_FOLDER}scripts.zip",
-            'py_job': eu.CLUSTER_APP_FOLDER + (app_args.get('launcher_file') or app_file),
+            'py_job': eu.CLUSTER_APP_FOLDER + (app_file or app_args.get('py_job') or app_args.get('launcher_file')),  # TODO: simplify business of getting application code upstream
             'mode': 'dev_EMR' if app_args.get('mode') == 'dev_local' else app_args.get('mode'),
             'deploy': 'none',
             'storage': 's3',
-            'jar_job': eu.CLUSTER_APP_FOLDER + (app_args.get('launcher_file') or app_file),
+            'jar_job': eu.CLUSTER_APP_FOLDER + (app_file or app_args.get('jar_job') or app_args.get('launcher_file')),
             }
         args.update(unoverridable_args)
 
@@ -580,7 +580,7 @@ class DeployPySparkScriptOnAws(object):
         if app_args.get('chain_dependencies'):
             args['spark_app_args'] += ' --chain_dependencies'
         
-        if app_args.get('job_param_file'):
+        if app_args.get('job_param_file') and app_args.get('py_job'):
             args['job_param_file'] = eu.CLUSTER_APP_FOLDER + app_args['job_param_file']
             args['spark_app_keys'] += '--job_param_file'
 
@@ -588,7 +588,7 @@ class DeployPySparkScriptOnAws(object):
             args['sql_file'] = eu.CLUSTER_APP_FOLDER + app_args['sql_file']
             args['spark_app_keys'] += '--sql_file'
 
-        if app_args.get('job_name'):
+        if app_args.get('job_name') and app_args.get('py_job'):
             args['job_name'] = app_args['job_name']
             args['spark_app_keys'] += '--job_name'
 

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -277,9 +277,14 @@ class DeployPySparkScriptOnAws(object):
         # ./jobs files and folders
         # TODO: extract code below in external function.
         files = []
+        folder_to_skip = ('bg-jobs')  # bg-jobs contains intermediate jars from scala compilation process.
         for (dirpath, dirnames, filenames) in os.walk(self.app_args['jobs_folder']):
             for file in filenames:
-                if file.endswith(".py") or file.endswith(".sql"):
+                if folder_to_skip in dirnames:
+                    dirnames.remove(folder_to_skip)
+                    continue
+
+                if file.endswith(".py") or file.endswith(".sql") or file.endswith(".jar"):
                     path = os.path.join(dirpath, file)
                     dir_tar = dirpath[len(self.app_args['jobs_folder']):]
                     path_tar = os.path.join(eu.JOB_FOLDER, dir_tar, file)

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -502,46 +502,46 @@ class DeployPySparkScriptOnAws(object):
             raise Exception("Step couldn't be added")
         time.sleep(1)  # Prevent ThrottlingException
 
+    # @staticmethod
+    # def get_spark_submit_args(app_file, app_args):
+
+    #     emr_mode = 'dev_EMR' if app_args['mode'] == 'dev_local' else app_args['mode']
+    #     launcher_file = app_args.get('launcher_file') or app_file
+
+    #     spark_submit_args = [
+    #         "spark-submit",
+    #         "--verbose",
+    #         "--py-files={}scripts.zip".format(eu.CLUSTER_APP_FOLDER),
+    #     ]
+    #     if app_args.get('load_connectors', '') == 'all':
+    #         package_str = ','.join(eu.PACKAGES_EMR_SPARK_3)
+    #         pac = [f"--packages={app_args.get('spark_packages')}"] if app_args.get('spark_packages') else [f"--packages={package_str}"]
+    #         jar = [f"--jars={app_args.get('spark_jars')}"] if app_args.get('spark_jars') else [f"--jars={eu.JARS}"]
+    #     else:
+    #         pac = []
+    #         jar = []
+    #     med = ["--driver-memory={}".format(app_args['driver-memory'])] if app_args.get('driver-memory') else []
+    #     cod = ["--driver-cores={}".format(app_args['driver-cores'])] if app_args.get('driver-cores') else []
+    #     mee = ["--executor-memory={}".format(app_args['executor-memory'])] if app_args.get('executor-memory') else []
+    #     coe = ["--executor-cores={}".format(app_args['executor-cores'])] if app_args.get('executor-cores') else []
+
+    #     spark_app_args = [
+    #         eu.CLUSTER_APP_FOLDER + launcher_file,
+    #         "--mode={}".format(emr_mode),
+    #         "--deploy=none",
+    #         "--storage=s3",
+    #         "--rerun_criteria={}".format(app_args.get('rerun_criteria')),
+    #     ]
+    #     jop = ['--job_param_file={}'.format(eu.CLUSTER_APP_FOLDER + eu.JOBS_METADATA_FILE)] if app_args.get('job_param_file') else []
+    #     dep = ["--dependencies"] if app_args.get('dependencies') else []
+    #     box = ["--chain_dependencies"] if app_args.get('chain_dependencies') else []
+    #     sql = ["--sql_file={}".format(eu.CLUSTER_APP_FOLDER + app_args['sql_file'])] if app_args.get('sql_file') else []
+    #     nam = ["--job_name={}".format(app_args['job_name'])] if app_args.get('job_name') else []
+
+    #     return spark_submit_args + pac + jar + med + cod + mee + coe + spark_app_args + jop + dep + box + sql + nam
+
     @staticmethod
     def get_spark_submit_args(app_file, app_args):
-
-        emr_mode = 'dev_EMR' if app_args['mode'] == 'dev_local' else app_args['mode']
-        launcher_file = app_args.get('launcher_file') or app_file
-
-        spark_submit_args = [
-            "spark-submit",
-            "--verbose",
-            "--py-files={}scripts.zip".format(eu.CLUSTER_APP_FOLDER),
-        ]
-        if app_args.get('load_connectors', '') == 'all':
-            package_str = ','.join(eu.PACKAGES_EMR_SPARK_3)
-            pac = [f"--packages={app_args.get('spark_packages')}"] if app_args.get('spark_packages') else [f"--packages={package_str}"]
-            jar = [f"--jars={app_args.get('spark_jars')}"] if app_args.get('spark_jars') else [f"--jars={eu.JARS}"]
-        else:
-            pac = []
-            jar = []
-        med = ["--driver-memory={}".format(app_args['driver-memory'])] if app_args.get('driver-memory') else []
-        cod = ["--driver-cores={}".format(app_args['driver-cores'])] if app_args.get('driver-cores') else []
-        mee = ["--executor-memory={}".format(app_args['executor-memory'])] if app_args.get('executor-memory') else []
-        coe = ["--executor-cores={}".format(app_args['executor-cores'])] if app_args.get('executor-cores') else []
-
-        spark_app_args = [
-            eu.CLUSTER_APP_FOLDER + launcher_file,
-            "--mode={}".format(emr_mode),
-            "--deploy=none",
-            "--storage=s3",
-            "--rerun_criteria={}".format(app_args.get('rerun_criteria')),
-        ]
-        jop = ['--job_param_file={}'.format(eu.CLUSTER_APP_FOLDER + eu.JOBS_METADATA_FILE)] if app_args.get('job_param_file') else []
-        dep = ["--dependencies"] if app_args.get('dependencies') else []
-        box = ["--chain_dependencies"] if app_args.get('chain_dependencies') else []
-        sql = ["--sql_file={}".format(eu.CLUSTER_APP_FOLDER + app_args['sql_file'])] if app_args.get('sql_file') else []
-        nam = ["--job_name={}".format(app_args['job_name'])] if app_args.get('job_name') else []
-
-        return spark_submit_args + pac + jar + med + cod + mee + coe + spark_app_args + jop + dep + box + sql + nam
-
-    @staticmethod
-    def get_spark_submit_args2(app_file, app_args):
         if app_args.get('py_job'):
             overridable_args = {
                 'spark_submit_args': '--verbose',

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -488,6 +488,7 @@ class DeployPySparkScriptOnAws(object):
         :return:
         """
         cmd_runner_args = self.get_spark_submit_args(app_file, app_args)
+        # import ipdb; ipdb.set_trace()
 
         response = c.add_job_flow_steps(
             JobFlowId=self.cluster_id,
@@ -506,44 +507,6 @@ class DeployPySparkScriptOnAws(object):
         else:
             raise Exception("Step couldn't be added")
         time.sleep(1)  # Prevent ThrottlingException
-
-    # @staticmethod
-    # def get_spark_submit_args(app_file, app_args):
-
-    #     emr_mode = 'dev_EMR' if app_args['mode'] == 'dev_local' else app_args['mode']
-    #     launcher_file = app_args.get('launcher_file') or app_file
-
-    #     spark_submit_args = [
-    #         "spark-submit",
-    #         "--verbose",
-    #         "--py-files={}scripts.zip".format(eu.CLUSTER_APP_FOLDER),
-    #     ]
-    #     if app_args.get('load_connectors', '') == 'all':
-    #         package_str = ','.join(eu.PACKAGES_EMR_SPARK_3)
-    #         pac = [f"--packages={app_args.get('spark_packages')}"] if app_args.get('spark_packages') else [f"--packages={package_str}"]
-    #         jar = [f"--jars={app_args.get('spark_jars')}"] if app_args.get('spark_jars') else [f"--jars={eu.JARS}"]
-    #     else:
-    #         pac = []
-    #         jar = []
-    #     med = ["--driver-memory={}".format(app_args['driver-memory'])] if app_args.get('driver-memory') else []
-    #     cod = ["--driver-cores={}".format(app_args['driver-cores'])] if app_args.get('driver-cores') else []
-    #     mee = ["--executor-memory={}".format(app_args['executor-memory'])] if app_args.get('executor-memory') else []
-    #     coe = ["--executor-cores={}".format(app_args['executor-cores'])] if app_args.get('executor-cores') else []
-
-    #     spark_app_args = [
-    #         eu.CLUSTER_APP_FOLDER + launcher_file,
-    #         "--mode={}".format(emr_mode),
-    #         "--deploy=none",
-    #         "--storage=s3",
-    #         "--rerun_criteria={}".format(app_args.get('rerun_criteria')),
-    #     ]
-    #     jop = ['--job_param_file={}'.format(eu.CLUSTER_APP_FOLDER + eu.JOBS_METADATA_FILE)] if app_args.get('job_param_file') else []
-    #     dep = ["--dependencies"] if app_args.get('dependencies') else []
-    #     box = ["--chain_dependencies"] if app_args.get('chain_dependencies') else []
-    #     sql = ["--sql_file={}".format(eu.CLUSTER_APP_FOLDER + app_args['sql_file'])] if app_args.get('sql_file') else []
-    #     nam = ["--job_name={}".format(app_args['job_name'])] if app_args.get('job_name') else []
-
-    #     return spark_submit_args + pac + jar + med + cod + mee + coe + spark_app_args + jop + dep + box + sql + nam
 
     @staticmethod
     def get_spark_submit_args(app_file, app_args):

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -502,7 +502,8 @@ class DeployPySparkScriptOnAws(object):
             raise Exception("Step couldn't be added")
         time.sleep(1)  # Prevent ThrottlingException
 
-    def get_spark_submit_args(self, app_file, app_args):
+    @staticmethod
+    def get_spark_submit_args(app_file, app_args):
 
         emr_mode = 'dev_EMR' if app_args['mode'] == 'dev_local' else app_args['mode']
         launcher_file = app_args.get('launcher_file') or app_file

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -515,15 +515,13 @@ class DeployPySparkScriptOnAws(object):
                 'spark_submit_args': '--verbose',
                 'spark_submit_keys': 'py-files',
                 'spark_app_args': '',
-                'spark_app_keys': 'mode--deploy--storage',
-                }
+                'spark_app_keys': 'mode--deploy--storage'}
         else:
             overridable_args = {
                 'spark_submit_args': '--verbose',
                 'spark_submit_keys': '',
                 'spark_app_args': '',
-                'spark_app_keys': '',
-                }
+                'spark_app_keys': ''}
 
         overridable_args.update(app_args)
         args = overridable_args.copy()
@@ -533,8 +531,7 @@ class DeployPySparkScriptOnAws(object):
             'mode': 'dev_EMR' if app_args.get('mode') == 'dev_local' else app_args.get('mode'),
             'deploy': 'none',
             'storage': 's3',
-            'jar_job': eu.CLUSTER_APP_FOLDER + (app_file or app_args.get('jar_job') or app_args.get('launcher_file')),
-            }
+            'jar_job': eu.CLUSTER_APP_FOLDER + (app_file or app_args.get('jar_job') or app_args.get('launcher_file'))}
         args.update(unoverridable_args)
 
         if app_args.get('load_connectors', '') == 'all':
@@ -544,10 +541,10 @@ class DeployPySparkScriptOnAws(object):
 
         if app_args.get('dependencies'):
             args['spark_app_args'] += ' --dependencies'
-        
+
         if app_args.get('chain_dependencies'):
             args['spark_app_args'] += ' --chain_dependencies'
-        
+
         if app_args.get('job_param_file') and app_args.get('py_job'):
             args['job_param_file'] = eu.CLUSTER_APP_FOLDER + app_args['job_param_file']
             args['spark_app_keys'] += '--job_param_file'
@@ -563,7 +560,7 @@ class DeployPySparkScriptOnAws(object):
         # TODO: implement better way to handle params, less case by case, to only deal with overloaded params
         jargs = eu.Job_Args_Parser(defaults_args={}, yml_args={}, job_args=args, cmd_args={}, build_yml_args=False, loaded_inputs={})
         return eu.Runner.create_spark_submit(jargs)
-    
+
     def run_aws_data_pipeline(self):
         self.s3_ops(self.session)
         if self.deploy_args.get('push_secrets', False):

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -542,20 +542,30 @@ class DeployPySparkScriptOnAws(object):
 
     @staticmethod
     def get_spark_submit_args2(app_file, app_args):
-        overridable_args = {
-            'spark_submit_args': '--verbose',
-            'spark_submit_keys': 'py-files',
-            'spark_app_args': '',
-            'spark_app_keys': 'mode--deploy--storage',
-            }
+        if app_args.get('py_job'):
+            overridable_args = {
+                'spark_submit_args': '--verbose',
+                'spark_submit_keys': 'py-files',
+                'spark_app_args': '',
+                'spark_app_keys': 'mode--deploy--storage',
+                }
+        else:
+            overridable_args = {
+                'spark_submit_args': '--verbose',
+                'spark_submit_keys': '',
+                'spark_app_args': '',
+                'spark_app_keys': '',
+                }
+
         overridable_args.update(app_args)
         args = overridable_args
         unoverridable_args = {
             'py-files': f"{eu.CLUSTER_APP_FOLDER}scripts.zip",
             'py_job': eu.CLUSTER_APP_FOLDER + (app_args.get('launcher_file') or app_file),
-            'mode': 'dev_EMR' if app_args['mode'] == 'dev_local' else app_args['mode'],
+            'mode': 'dev_EMR' if app_args.get('mode') == 'dev_local' else app_args.get('mode'),
             'deploy': 'none',
             'storage': 's3',
+            'jar_job': eu.CLUSTER_APP_FOLDER + (app_args.get('launcher_file') or app_file),
             }
         args.update(unoverridable_args)
 

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -853,6 +853,9 @@ class Job_Args_Parser():
         args['is_incremental'] = self.set_is_incremental(args.get('inputs', {}), args.get('output', {}))
         if args.get('output'):
             args['output']['type'] = args.pop('output.type', None) or args['output'].get('type', 'none')
+        if args.get('spark_app_args'):  # hack to have scala sample job working. TODO: remove hardcoded case when made more generic
+            args['spark_app_args'] = Path_Handler(args['spark_app_args'], args.get('base_path'), args.get('root_path')).path
+
         return args
 
     # TODO: update to put back in use later.
@@ -905,11 +908,22 @@ class Job_Args_Parser():
 
 class Path_Handler():
     def __init__(self, path, base_path=None, root_path=None):
-        if base_path and '{base_path}' in path:
-            path = path.replace('{base_path}', base_path)
-        if root_path and '{root_path}' in path:
-            path = path.replace('{root_path}', root_path)
         self.path = path
+        self.base_path = base_path
+        self.root_path = root_path
+        
+        # if base_path and '{base_path}' in path:
+        #     path = path.replace('{base_path}', base_path)
+        # if root_path and '{root_path}' in path:
+        #     path = path.replace('{root_path}', root_path)
+        self.path = self.expand_base()
+
+    def expand_base(self):
+        if self.base_path and '{base_path}' in self.path:
+            path = self.path.replace('{base_path}', self.base_path)
+        if self.root_path and '{root_path}' in self.path:
+            path = self.path.replace('{root_path}', self.root_path)
+        return path
 
     def expand_later(self):
         path = self.path

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -983,12 +983,16 @@ class Runner():
         # Loading from jupyter notebooks for dashboarding goes through 'InputLoader', away from this if sequence.
 
         # Executing or deploying
-        if jargs.deploy in ('none'):  # when executing job code
+        # import ipdb; ipdb.set_trace()
+        if jargs.deploy == 'none' and jargs.merged_args.get('py_job'):  # when running python job on the spot
             job = self.launch_run_mode(job)
-        elif jargs.deploy in ('EMR', 'EMR_Scheduled', 'airflow', 'code'):  # when deploying to AWS for execution there
-            self.launch_deploy_mode(job.jargs.get_deploy_args(), job.jargs.get_app_args())
-        elif jargs.deploy in ('local_spark_submit'):
+        elif jargs.deploy == 'local_spark_submit' or (jargs.deploy == 'none' and jargs.merged_args.get('jar_job')):  # when running job on the spot through spark-submit.
             self.launch_run_mode_spark_submit(jargs)
+        elif jargs.deploy in ('EMR', 'EMR_Scheduled', 'airflow', 'code'):  # when deploying to AWS for execution there
+            # self.launch_deploy_mode(job.jargs.get_deploy_args(), job.jargs.get_app_args())
+            self.launch_deploy_mode(jargs.get_deploy_args(), jargs.get_app_args())
+        # elif jargs.deploy in ('local_spark_submit'):
+        #     self.launch_run_mode_spark_submit(jargs)
         return job
 
     @staticmethod

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1124,6 +1124,8 @@ class Runner():
             kv = f"--{item}={jargs.merged_args[item]}" if jargs.merged_args.get(item) != 'no value' else f"--{item}"
             spark_submit_cmd.append(kv)
 
+        if jargs.merged_args.get('spark_app_args'):
+            spark_submit_cmd.append(jargs.spark_app_args)
         return spark_submit_cmd
 
     @staticmethod

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1074,7 +1074,7 @@ class Runner():
         cmdline_str = " ".join(cmdline)
         logger.info(f'About to run spark submit command line: {cmdline_str}')
         os.system(cmdline_str)
-        # TODO: test with dependencies.
+        ### TODO: test with dependencies.
 
     @staticmethod
     def create_spark_submit(jargs):

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1074,7 +1074,7 @@ class Runner():
         cmdline_str = " ".join(cmdline)
         logger.info(f'About to run spark submit command line: {cmdline_str}')
         os.system(cmdline_str)
-        ### TODO: test with dependencies.
+        # ### TODO: test with dependencies.
 
     @staticmethod
     def create_spark_submit(jargs):

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -882,11 +882,12 @@ class Job_Args_Parser():
         return any(['inc_field' in inputs[item] for item in inputs.keys()]) or 'inc_field' in output
 
     def validate(self):
-        if self.merged_args.get('py_job') is None:
-            raise Exception("Couldn't find py_job, i.e. the python job to execute the code."
+        if self.merged_args.get('py_job') is None and self.merged_args.get('jar_job') is None:
+            raise Exception("Couldn't find py_job not jar_job, i.e. the job to execute the code."
                             "It should be either the name of the job if it ends with .py, "
-                            "or it should be set in a parameter called py_job.")
+                            "or it should be set in a parameter called py_job or jar_job.")
         if (self.merged_args.get('sql_file') is None and
+                self.merged_args.get('jar_job') is None and
                 (self.merged_args['py_job'].endswith('sql_pandas_job.py') or
                     self.merged_args['py_job'].endswith('sql_spark_job.py'))):
             raise Exception("Couldn't find sql_file, i.e. the sql file with the transformation."

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -949,13 +949,6 @@ class Runner():
         cmd_args = self.set_commandline_args(parser) if job_args.get('parse_cmdline') else {}
 
         # Building "job", which will include all job args.
-        # jargs = Job_Args_Parser(defaults_args=defaults_args, yml_args=None, job_args=job_args, cmd_args=cmd_args, build_yml_args=True, loaded_inputs={})
-        # is_py_job = job_args.get('py_job') or cmd_args.get('py_job')  # TODO: check to add yml_args
-        # is_jar_job = job_args.get('jar_job') or cmd_args.get('jar_job')  # TODO: same
-        # is_py_job = jargs.merged_args.get('py_job')
-        # is_jar_job = jargs.merged_args.get('jar_job')
-        # print('####', is_py_job, ' --- ', is_jar_job)
-        # import ipdb; ipdb.set_trace()
         if Job is None:  # when job run from "python launcher.py --job_name=some_name_from_job_metadata_file"
             # Implies 'job_name' will be available in cmd_args.
             jargs = Job_Args_Parser(defaults_args=defaults_args, yml_args=None, job_args=job_args, cmd_args=cmd_args, build_yml_args=True, loaded_inputs={})  # yml_args loaded inside based on 
@@ -1040,8 +1033,8 @@ class Runner():
             'add_created_at': 'true',  # set as string to be overrideable in cmdline.
             'no_fw_cache': False,
             'spark_boot': True,  # options ('spark', 'pandas') (experimental).
-            'spark_submit_keys': '',
-            'spark_app_keys': '',
+            # 'spark_submit_keys': '',
+            # 'spark_app_keys': '',
             # 'spark_app_args': '',
             'dry_run': False,
         }
@@ -1089,7 +1082,6 @@ class Runner():
         cmdline = self.create_spark_submit(jargs)
         cmdline_str = " ".join(cmdline)
         logger.info(f'About to run spark submit command line: {cmdline_str}')
-        # import ipdb; ipdb.set_trace()
         if not jargs.merged_args.get('dry_run'):
             os.system(cmdline_str)
         # ### TODO: test with dependencies.
@@ -1101,9 +1093,8 @@ class Runner():
         spark_submit_cmd = ["spark-submit"]
 
         # Get spark submit args (i.e. before launcher)
-        spark_submit_keys = jargs.merged_args.get('spark_submit_keys')
+        spark_submit_keys = jargs.merged_args.get('spark_submit_keys', '')
         spark_submit_keys_lst = [] if spark_submit_keys.split('--') == [''] else spark_submit_keys.split('--')
-        # import ipdb; ipdb.set_trace()
         for item in spark_submit_keys_lst:
             if jargs.merged_args.get(item) is None:
                 raise Exception(f"The param '{item}' set from spark-submit (see list in spark_submit_args) is missing in your list of params '{jargs.merged_args}'.")
@@ -1111,11 +1102,14 @@ class Runner():
             kv = f"--{item}={jargs.merged_args[item]}" if jargs.merged_args.get(item) != 'no value' else f"--{item}"
             spark_submit_cmd.append(kv)
 
+        if jargs.merged_args.get('spark_submit_args'):
+            spark_submit_cmd.append(jargs.spark_submit_args)
+
         # Add launcher
         spark_submit_cmd.append(launcher_file)
 
         # Get spark app args (i.e. after launcher)
-        spark_app_keys = jargs.merged_args.get('spark_app_keys')
+        spark_app_keys = jargs.merged_args.get('spark_app_keys', '')
         spark_app_keys_lst = [] if spark_app_keys.split('--') == [''] else spark_app_keys.split('--')
         for item in spark_app_keys_lst:
             if jargs.merged_args.get(item) is None:

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -958,7 +958,7 @@ class Runner():
         # Building "job", which will include all job args.
         if Job is None:  # when job run from "python launcher.py --job_name=some_name_from_job_metadata_file"
             # Implies 'job_name' will be available in cmd_args.
-            jargs = Job_Args_Parser(defaults_args=defaults_args, yml_args=None, job_args=job_args, cmd_args=cmd_args, build_yml_args=True, loaded_inputs={})  # yml_args loaded inside based on 
+            jargs = Job_Args_Parser(defaults_args=defaults_args, yml_args=None, job_args=job_args, cmd_args=cmd_args, build_yml_args=True, loaded_inputs={})
             if jargs.merged_args.get('py_job'):
                 Job = get_job_class(jargs.py_job)
                 job = Job(jargs=jargs)

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1014,7 +1014,6 @@ class Runner():
             'deploy': 'none',
             'mode': 'dev_local',
             'job_param_file': JOBS_METADATA_FILE,
-            # 'job_name': None,
             'sql_file': None,
             'connection_file': CONNECTION_FILE,
             'jobs_folder': JOB_FOLDER,
@@ -1038,7 +1037,7 @@ class Runner():
             'add_created_at': 'true',  # set as string to be overrideable in cmdline.
             'no_fw_cache': False,
             'spark_boot': True,  # options ('spark', 'pandas') (experimental).
-            'dry_run': False,
+            # 'dry_run': False,
         }
         redshift = ['enable_redshift_push', 'schema', 'redshift_s3_tmp_dir', 'redshift_s3_tmp_dir']
         spark = ['no_fw_cache', 'spark_boot', 'spark_version']
@@ -1086,7 +1085,6 @@ class Runner():
         logger.info(f'About to run spark submit command line: {cmdline_str}')
         if not jargs.merged_args.get('dry_run'):
             os.system(cmdline_str)
-        # ### TODO: test with dependencies.
 
     @staticmethod
     def create_spark_submit(jargs):

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -911,11 +911,6 @@ class Path_Handler():
         self.path = path
         self.base_path = base_path
         self.root_path = root_path
-        
-        # if base_path and '{base_path}' in path:
-        #     path = path.replace('{base_path}', base_path)
-        # if root_path and '{root_path}' in path:
-        #     path = path.replace('{root_path}', root_path)
         self.path = self.expand_base()
 
     def expand_base(self):
@@ -984,16 +979,12 @@ class Runner():
         # Loading from jupyter notebooks for dashboarding goes through 'InputLoader', away from this if sequence.
 
         # Executing or deploying
-        # import ipdb; ipdb.set_trace()
         if jargs.deploy == 'none' and jargs.merged_args.get('py_job'):  # when running python job on the spot
             job = self.launch_run_mode(job)
         elif jargs.deploy == 'local_spark_submit' or (jargs.deploy == 'none' and jargs.merged_args.get('jar_job')):  # when running job on the spot through spark-submit.
             self.launch_run_mode_spark_submit(jargs)
         elif jargs.deploy in ('EMR', 'EMR_Scheduled', 'airflow', 'code'):  # when deploying to AWS for execution there
-            # self.launch_deploy_mode(job.jargs.get_deploy_args(), job.jargs.get_app_args())
             self.launch_deploy_mode(jargs.get_deploy_args(), jargs.get_app_args())
-        # elif jargs.deploy in ('local_spark_submit'):
-        #     self.launch_run_mode_spark_submit(jargs)
         return job
 
     @staticmethod
@@ -1130,7 +1121,6 @@ class Runner():
         if jargs.merged_args.get('spark_app_args'):
             spark_submit_cmd.append(jargs.spark_app_args)
         spark_app_keys = jargs.merged_args.get('spark_app_keys', '')
-        # spark_app_keys_lst = [] if spark_app_keys.split('--') == [''] else spark_app_keys.split('--')
         spark_app_keys_lst = [item for item in spark_app_keys.split('--') if item != '']
         for item in spark_app_keys_lst:
             if item not in jargs.merged_args.keys():

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -919,10 +919,11 @@ class Path_Handler():
         self.path = self.expand_base()
 
     def expand_base(self):
-        if self.base_path and '{base_path}' in self.path:
-            path = self.path.replace('{base_path}', self.base_path)
-        if self.root_path and '{root_path}' in self.path:
-            path = self.path.replace('{root_path}', self.root_path)
+        path = self.path
+        if self.base_path and '{base_path}' in path:
+            path = path.replace('{base_path}', self.base_path)
+        if self.root_path and '{root_path}' in path:
+            path = path.replace('{root_path}', self.root_path)
         return path
 
     def expand_later(self):

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -956,16 +956,14 @@ class Runner():
         cmd_args = self.set_commandline_args(parser) if job_args.get('parse_cmdline') else {}
 
         # Building "job", which will include all job args.
-        if Job is None:  # when job run from "python launcher.py --job_name=some_name_from_job_metadata_file"
-            # Implies 'job_name' will be available in cmd_args.
+        if Job is None:  # when job run from "python launcher.py --job_name=some_name_from_job_metadata_file", Implies 'job_name' available in cmd_args.
             jargs = Job_Args_Parser(defaults_args=defaults_args, yml_args=None, job_args=job_args, cmd_args=cmd_args, build_yml_args=True, loaded_inputs={})
             if jargs.merged_args.get('py_job'):
                 Job = get_job_class(jargs.py_job)
                 job = Job(jargs=jargs)
             elif jargs.merged_args.get('jar_job'):
                 job = None
-        else:  # when job run from "python some_job.py", i.e. python job
-            # Implies Job Class exist, so 'job_name' and 'py_code' will be derived from Job instance.
+        else:  # when job run from "python some_job.py", i.e. python job, Implies Job class exist, so it is a python job, so 'job_name' will be derived from Job class.
             job = Job(pre_jargs={'defaults_args': defaults_args, 'job_args': job_args, 'cmd_args': cmd_args})  # can provide jargs directly here since job_file (and so job_name) needs to be extracted from job first. So, letting job build jargs.
             jargs = job.jargs
         # Loading from jupyter notebooks for dashboarding goes through 'InputLoader', away from this if sequence.

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1033,9 +1033,6 @@ class Runner():
             'add_created_at': 'true',  # set as string to be overrideable in cmdline.
             'no_fw_cache': False,
             'spark_boot': True,  # options ('spark', 'pandas') (experimental).
-            # 'spark_submit_keys': '',
-            # 'spark_app_keys': '',
-            # 'spark_app_args': '',
             'dry_run': False,
         }
         redshift = ['enable_redshift_push', 'schema', 'redshift_s3_tmp_dir', 'redshift_s3_tmp_dir']
@@ -1228,7 +1225,7 @@ class Flow():
                         loaded_inputs[in_name] = df[in_properties['from']]
 
             # Get jargs
-            jargs = Job_Args_Parser(self.launch_jargs.defaults_args, yml_args, self.launch_jargs.job_args, self.launch_jargs.cmd_args, loaded_inputs=loaded_inputs)
+            jargs = Job_Args_Parser(self.launch_jargs.defaults_args, yml_args, self.launch_jargs.job_args, self.launch_jargs.cmd_args, build_yml_args=False, loaded_inputs=loaded_inputs)
 
             Job = get_job_class(yml_args['py_job'])
             job = Job(jargs=jargs, loaded_inputs=loaded_inputs)

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1093,33 +1093,32 @@ class Runner():
         spark_submit_cmd = ["spark-submit"]
 
         # Get spark submit args (i.e. before launcher)
+        if jargs.merged_args.get('spark_submit_args'):
+            spark_submit_cmd.append(jargs.spark_submit_args)
         spark_submit_keys = jargs.merged_args.get('spark_submit_keys', '')
         spark_submit_keys_lst = [] if spark_submit_keys.split('--') == [''] else spark_submit_keys.split('--')
         for item in spark_submit_keys_lst:
-            if jargs.merged_args.get(item) is None:
+            if item not in jargs.merged_args.keys():
                 raise Exception(f"The param '{item}' set from spark-submit (see list in spark_submit_args) is missing in your list of params '{jargs.merged_args}'.")
 
             kv = f"--{item}={jargs.merged_args[item]}" if jargs.merged_args.get(item) != 'no value' else f"--{item}"
             spark_submit_cmd.append(kv)
 
-        if jargs.merged_args.get('spark_submit_args'):
-            spark_submit_cmd.append(jargs.spark_submit_args)
-
         # Add launcher
         spark_submit_cmd.append(launcher_file)
 
         # Get spark app args (i.e. after launcher)
+        if jargs.merged_args.get('spark_app_args'):
+            spark_submit_cmd.append(jargs.spark_app_args)
         spark_app_keys = jargs.merged_args.get('spark_app_keys', '')
         spark_app_keys_lst = [] if spark_app_keys.split('--') == [''] else spark_app_keys.split('--')
         for item in spark_app_keys_lst:
-            if jargs.merged_args.get(item) is None:
+            if item not in jargs.merged_args.keys():
                 raise Exception(f"The param '{item}' set from spark-submit (see list in spark_app_args) is missing in your list of params '{jargs.merged_args}'.")
 
             kv = f"--{item}={jargs.merged_args[item]}" if jargs.merged_args.get(item) != 'no value' else f"--{item}"
             spark_submit_cmd.append(kv)
 
-        if jargs.merged_args.get('spark_app_args'):
-            spark_submit_cmd.append(jargs.spark_app_args)
         return spark_submit_cmd
 
     @staticmethod

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -855,7 +855,7 @@ class Job_Args_Parser():
             args['output']['type'] = args.pop('output.type', None) or args['output'].get('type', 'none')
         return args
 
-    # TODO: modify later since not used now
+    # TODO: update to put back in use later.
     def set_inputs(self, args, loaded_inputs):
         # inputs_in_args = any([item.startswith('input_') for item in cmd_args.keys()])
         # if inputs_in_args:
@@ -869,7 +869,7 @@ class Job_Args_Parser():
         else:
             return args.get('inputs', {})
 
-    # TODO: modify later since not used now
+    # TODO: update to put back in use later.
     # def set_output(self, cmd_args, yml_args):
     #     output_in_args = any([item == 'output_path' for item in cmd_args.keys()])
     #     if output_in_args:
@@ -1096,7 +1096,7 @@ class Runner():
         if jargs.merged_args.get('spark_submit_args'):
             spark_submit_cmd.append(jargs.spark_submit_args)
         spark_submit_keys = jargs.merged_args.get('spark_submit_keys', '')
-        spark_submit_keys_lst = [] if spark_submit_keys.split('--') == [''] else spark_submit_keys.split('--')
+        spark_submit_keys_lst = [item for item in spark_submit_keys.split('--') if item != '']
         for item in spark_submit_keys_lst:
             if item not in jargs.merged_args.keys():
                 raise Exception(f"The param '{item}' set from spark-submit (see list in spark_submit_args) is missing in your list of params '{jargs.merged_args}'.")
@@ -1111,7 +1111,8 @@ class Runner():
         if jargs.merged_args.get('spark_app_args'):
             spark_submit_cmd.append(jargs.spark_app_args)
         spark_app_keys = jargs.merged_args.get('spark_app_keys', '')
-        spark_app_keys_lst = [] if spark_app_keys.split('--') == [''] else spark_app_keys.split('--')
+        # spark_app_keys_lst = [] if spark_app_keys.split('--') == [''] else spark_app_keys.split('--')
+        spark_app_keys_lst = [item for item in spark_app_keys.split('--') if item != '']
         for item in spark_app_keys_lst:
             if item not in jargs.merged_args.keys():
                 raise Exception(f"The param '{item}' set from spark-submit (see list in spark_app_args) is missing in your list of params '{jargs.merged_args}'.")

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1084,12 +1084,12 @@ class Runner():
 
         # Get spark submit args (i.e. before launcher)
         spark_submit_args = jargs.merged_args.get('spark_submit_args')
-        spark_submit_args_lst = [] if spark_submit_args.split('--')==[''] else spark_submit_args.split('--')
+        spark_submit_args_lst = [] if spark_submit_args.split('--') == [''] else spark_submit_args.split('--')
         # import ipdb; ipdb.set_trace()
         for item in spark_submit_args_lst:
             if jargs.merged_args.get(item) is None:
                 raise Exception(f"The param '{item}' set from spark-submit (see list in spark_submit_args) is missing in your list of params '{jargs.merged_args}'.")
-            
+
             kv = f"--{item}={jargs.merged_args[item]}" if jargs.merged_args.get(item) != 'no value' else f"--{item}"
             spark_submit_cmd.append(kv)
 
@@ -1098,11 +1098,11 @@ class Runner():
 
         # Get spark app args (i.e. after launcher)
         spark_app_args = jargs.merged_args.get('spark_app_args')
-        spark_app_args_lst = [] if spark_app_args.split('--')==[''] else spark_app_args.split('--')
+        spark_app_args_lst = [] if spark_app_args.split('--') == [''] else spark_app_args.split('--')
         for item in spark_app_args_lst:
             if jargs.merged_args.get(item) is None:
                 raise Exception(f"The param '{item}' set from spark-submit (see list in spark_app_args) is missing in your list of params '{jargs.merged_args}'.")
-            
+
             kv = f"--{item}={jargs.merged_args[item]}" if jargs.merged_args.get(item) != 'no value' else f"--{item}"
             spark_submit_cmd.append(kv)
 

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1153,7 +1153,8 @@ class Runner():
 
         sc = spark.sparkContext
         sc_sql = SQLContext(sc)
-        logger.info('Spark Config: {}'.format(sc.getConf().getAll()))
+        logger.info(f'Spark Version: {sc.version}')
+        logger.info(f'Spark Config: {sc.getConf().getAll()}')
         return sc, sc_sql
 
 


### PR DESCRIPTION
Implemented the ability to execute scala (or other jvm languates) jobs through the jar. See job examples/run_scala_job to showcase it. Implied
 * new deploy mode `local_spark_submit` to force running job through spark submit. done by default for jobs that have a `jar_job` param.
 * adding code to execute spark-submit locally (for both python and jar jobs) and remove the equivalent code that was done in deploy side before and was mostly hardcoded. Now more flexible. spark-submit args now customizable. 
 * added jar job files to zip for shipping to aws
 * remove reliance on "job" instance 
 * added unit-test for create_spark_submit()

Other:
 * improved class Job_Args_Parser to better control on whether to load from yml_args.
 * got pb with github action, not loading tests properly anymore, including for CI runs that ran successfully before. Seems due to pytest that moved to 8.0.0. Forced it back to 7.4.4. 
  * log Spark Version