### PR TITLE
Add athena registration

### DIFF
--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -270,6 +270,26 @@ jobs:
     spark_app_args: '{base_path}/wordcount_example/input/sample_text.txt'
     load_connectors: none
   
+  examples/ex13_register_athena_job:
+    description: "Sample .... Setup to be run locally, while pushing data to cloud and registering data to athena in AWS."
+    # py_job: jobs/examples/ex7_pandas_job.py
+    py_job: jobs/examples/ex1_frameworked_job.py
+    inputs:
+      # some_events: {'path':"./data/wiki_example/input/{latest}/", 'type':'csv', 'df_type':'pandas'}
+      # other_events: {'path':"./data/wiki_example/input/{latest}/", 'type':'csv', 'df_type':'pandas'}
+      some_events: {'path':"./data/wiki_example/input/{latest}/", 'type':'csv'}
+      other_events: {'path':"./data/wiki_example/input/{latest}/", 'type':'csv'}
+    # output: {'path':'{base_path}/wiki_example/output_ex7_pandas/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas'}
+    output: {'path':'{base_path}/wiki_example/output_ex7_pandas/{now}/', 'type':'csv'}
+    base_path: 's3a://mylake-dev/pipelines_data'
+    # register_to_athena: {'table': '{schema}.ex1_frameworked'}
+    register_to_athena: {'table': 'database_testap.ex1_frameworked'}
+    enable_redshift_push: True
+    aws_config_file:  conf/aws_config.cfg
+    aws_setup: dev
+    load_connectors: all
+    # spark_boot: False
+
   # wordcount_raw_job: #Job exists but doesn't rely on jobs_metadata entries
 
   # ----- Marketing Jobs --------

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -202,7 +202,7 @@ jobs:
       table_to_copy: {'type':'mysql', 'db_table': 'some_schema.some_table', 'creds': 'some_mysql_cred_section', 'note':'creds defined in conf/connections.cfg'}
     output: {'path':'{base_path}/db_example/output_ex9_mysql_direct/{now}/', 'type':'csv'}
     load_connectors: all
-    enable_redshift_push: True
+    enable_db_push: True
 
   examples/ex9_clickhouse_job.py:
     db_inputs: {'creds': 'some_clickhouse_cred_section', 'note':'API Job that relies on creds from conf/connections.cfg'}
@@ -215,7 +215,7 @@ jobs:
     output: {'path':'{base_path}/db_example/output_ex9_clickhouse_direct/{now}/', 'type':'csv'}
     copy_to_clickhouse: {'creds': 'some_clickhouse_cred_section', 'table': 'public.test_push_arthur'}
     load_connectors: all
-    enable_redshift_push: True
+    enable_db_push: True
 
   examples/ex10_excel_load_job:
     py_job: jobs/generic/copy_job.py
@@ -279,7 +279,7 @@ jobs:
     output: {'path':'{base_path}/wiki_example/output_ex7_pandas/{now}/', 'type':'csv'}
     base_path: 's3a://mylake-dev/pipelines_data'
     register_to_athena: {'table': 'sandbox.ex1_frameworked'}  # implies sandbox schema created, to be done with "CREATE DATABASE sandbox;" in SQL editor
-    enable_redshift_push: True
+    enable_db_push: True
     aws_config_file:  conf/aws_config.cfg
     aws_setup: dev
     load_connectors: all
@@ -373,7 +373,7 @@ common_params:
       aws_setup:        pro
       jobs_folder:      jobs/
       load_connectors: all
-      enable_redshift_push: True
+      enable_db_push: True
       save_schemas: False
       manage_git_info: True
     dev_EMR:
@@ -384,7 +384,7 @@ common_params:
       aws_setup:        dev
       jobs_folder:      jobs/
       load_connectors: all
-      enable_redshift_push: False
+      enable_db_push: False
       save_schemas: False
       manage_git_info: True
     dev_local:
@@ -393,6 +393,6 @@ common_params:
       schema: sandbox
       load_connectors: none
       aws_config_file:  none
-      enable_redshift_push: False
+      enable_db_push: False
       save_schemas: True
       manage_git_info: False

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -282,6 +282,7 @@ jobs:
     enable_db_push: True
     aws_config_file:  conf/aws_config.cfg
     aws_setup: dev
+    athena_out: s3://mylake-dev/pipelines_data/athena_data/
     load_connectors: all
 
   # wordcount_raw_job: #Job exists but doesn't rely on jobs_metadata entries

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -271,24 +271,18 @@ jobs:
     load_connectors: none
   
   examples/ex13_register_athena_job:
-    description: "Sample .... Setup to be run locally, while pushing data to cloud and registering data to athena in AWS."
-    # py_job: jobs/examples/ex7_pandas_job.py
+    description: "Job to demo registering data to Athena. Setup to be run locally, while pushing data to cloud and registering data to athena in AWS."
     py_job: jobs/examples/ex1_frameworked_job.py
     inputs:
-      # some_events: {'path':"./data/wiki_example/input/{latest}/", 'type':'csv', 'df_type':'pandas'}
-      # other_events: {'path':"./data/wiki_example/input/{latest}/", 'type':'csv', 'df_type':'pandas'}
       some_events: {'path':"./data/wiki_example/input/{latest}/", 'type':'csv'}
       other_events: {'path':"./data/wiki_example/input/{latest}/", 'type':'csv'}
-    # output: {'path':'{base_path}/wiki_example/output_ex7_pandas/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas'}
     output: {'path':'{base_path}/wiki_example/output_ex7_pandas/{now}/', 'type':'csv'}
     base_path: 's3a://mylake-dev/pipelines_data'
-    # register_to_athena: {'table': '{schema}.ex1_frameworked'}
-    register_to_athena: {'table': 'database_testap.ex1_frameworked'}
+    register_to_athena: {'table': 'sandbox.ex1_frameworked'}  # implies sandbox schema created.
     enable_redshift_push: True
     aws_config_file:  conf/aws_config.cfg
     aws_setup: dev
     load_connectors: all
-    # spark_boot: False
 
   # wordcount_raw_job: #Job exists but doesn't rely on jobs_metadata entries
 

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -278,7 +278,7 @@ jobs:
       other_events: {'path':"./data/wiki_example/input/{latest}/", 'type':'csv'}
     output: {'path':'{base_path}/wiki_example/output_ex7_pandas/{now}/', 'type':'csv'}
     base_path: 's3a://mylake-dev/pipelines_data'
-    register_to_athena: {'table': 'sandbox.ex1_frameworked'}  # implies sandbox schema created.
+    register_to_athena: {'table': 'sandbox.ex1_frameworked'}  # implies sandbox schema created, to be done with "CREATE DATABASE sandbox;" in SQL editor
     enable_redshift_push: True
     aws_config_file:  conf/aws_config.cfg
     aws_setup: dev

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -261,7 +261,7 @@ jobs:
       - examples/ex1_sql_job.sql
       - examples/ex7_pandas_job.py
 
-  examples/run_scala_job:
+  examples/ex12_run_scala_job:
     description: "Sample spark scala code (compiled into a jar), executed through spark-submit"
     jar_job: 'jobs/examples/ex12_scala_job/target/spark_scala_job_2.13-1.0.jar'
     scala_job: 'jobs/examples/ex12_scala_job/src/spark_scala_job.scala'  # for ref, compilation to be done manually

--- a/dashboards/wikipedia_demo_dashboard.ipynb
+++ b/dashboards/wikipedia_demo_dashboard.ipynb
@@ -35,7 +35,7 @@
       " 'description': \"Showcase a Dashboard using 'panel', based on dummy wikipedia \"\n",
       "                'data (experimental).',\n",
       " 'email_cred_section': 'some_email_cred_section',\n",
-      " 'enable_redshift_push': False,\n",
+      " 'enable_db_push': False,\n",
       " 'inputs': {'ex1_sql': {'df_type': 'pandas',\n",
       "                        'path': '{base_path}/wiki_example_sql/output_ex1_sql_pandas/{latest}/dataset.csv',\n",
       "                        'type': 'csv'},\n",

--- a/notebooks/inspect_ex7_pandas_job.ipynb
+++ b/notebooks/inspect_ex7_pandas_job.ipynb
@@ -159,7 +159,7 @@
       " 'description': 'job loading and processing data with pandas. No spark '\n",
       "                'involved.',\n",
       " 'email_cred_section': 'some_email_cred_section',\n",
-      " 'enable_redshift_push': False,\n",
+      " 'enable_db_push': False,\n",
       " 'inputs': {'other_events': {'df_type': 'pandas',\n",
       "                             'path': '{base_path}/wiki_example/input/',\n",
       "                             'path_expanded': './tests/fixtures/data_sample//wiki_example/input/',\n",

--- a/yaetos/athena.py
+++ b/yaetos/athena.py
@@ -1,0 +1,52 @@
+"""Helper functions for athena."""
+import boto3
+from yaetos.logger import setup_logging
+logger = setup_logging('Athena')
+
+
+def register_table(types, name_tb, schema, output_info, creds_or_file, is_incremental):
+    # db = creds_or_file[connection_profile]
+    description = 'some description'
+    description_statement = f'COMMENT "{description}"' if description else ''
+    output_folder = output_info['path_expanded'].replace('s3a', 's3')
+    query_folder = 's3://mylake-dev/pipelines_data/athena_data/'
+
+    types_str = ''
+    # ii = 0
+    ii_max = len(types) - 1
+    for ii, (col_name, col_type) in enumerate(types.items()):
+        # ii += 1
+        types_str += f"`{col_name}` {col_type}"
+        types_str += ", \n" if ii < ii_max else ''
+
+    # import ipdb; ipdb.set_trace()
+    if output_info['type'] == 'csv':
+        create_table_query = f"""
+            CREATE EXTERNAL TABLE IF NOT EXISTS `{schema}`.`{name_tb}` (
+            {types_str}
+            ) {description_statement}
+            ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
+            WITH SERDEPROPERTIES ('field.delim' = ',')
+            STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat' OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+            LOCATION '{output_folder}'
+            TBLPROPERTIES ('classification' = 'csv');
+        """
+        logger.info(f"Table registration with : \n{create_table_query} \n")
+    else:
+        raise Exception('Athena table registration not setup for other than csv files.')    
+
+    # Start the query execution
+    region_name = 'eu-west-3'
+    client = boto3.client('athena', region_name=region_name)
+    response = client.start_query_execution(
+        QueryString=create_table_query,
+        QueryExecutionContext={
+            'Database': schema
+        },
+        ResultConfiguration={
+            'OutputLocation': query_folder
+        },
+    )
+    # logger.info(f"Registered table to athena '{schema}.{name_tb}', using connection profile '{connection_profile}', with QueryExecutionId: {response['QueryExecutionId']}")
+    logger.info(f"Registered table to athena '{schema}.{name_tb}'.")
+

--- a/yaetos/athena.py
+++ b/yaetos/athena.py
@@ -1,14 +1,14 @@
 """Helper functions for athena."""
 import boto3
+import os
+from configparser import ConfigParser
 from yaetos.logger import setup_logging
 logger = setup_logging('Athena')
 
 
-def register_table(types, name_tb, schema, output_info, description=None):
-    # TODO: Check to support "is_incremental"
-    description_statement = f'COMMENT "{description}"' if description else ''
+def register_table(types, name_tb, schema, output_info, args):
+    description_statement = f"""COMMENT "{args['description']}" """ if args.get('description') else ''
     output_folder = output_info['path_expanded'].replace('s3a', 's3')
-    query_folder = 's3://mylake-dev/pipelines_data/athena_data/'
 
     types_str = ''
     ii_max = len(types) - 1
@@ -32,12 +32,22 @@ def register_table(types, name_tb, schema, output_info, description=None):
         raise Exception('Athena table registration not setup for other than csv files.')    
 
     # Start the query execution
-    region_name = 'eu-west-3'
+    if args.get('mode') == 'dev_local':
+        config = ConfigParser()
+        assert os.path.isfile(args.get('aws_config_file'))
+        config.read(args.get('aws_config_file'))
+        # profile_name = config.get(args.get('aws_setup'), 'profile_name')
+        region_name = config.get(args.get('aws_setup'), 's3_region')
+        # region_name = boto3.Session(profile_name=profile_name).region_name
+    else:
+        region_name = boto3.Session().region_name
+
     client = boto3.client('athena', region_name=region_name)
     response = client.start_query_execution(
         QueryString=create_table_query,
         QueryExecutionContext={'Database': schema},
-        ResultConfiguration={'OutputLocation': query_folder},
+        ResultConfiguration={'OutputLocation': args.get('athena_out')},
     )
     logger.info(f"Registered table to athena '{schema}.{name_tb}', with QueryExecutionId: {response['QueryExecutionId']}.")
+    # TODO: Check to support "is_incremental"
 

--- a/yaetos/athena.py
+++ b/yaetos/athena.py
@@ -28,6 +28,15 @@ def register_table(types, name_tb, schema, output_info, args):
             TBLPROPERTIES ('classification' = 'csv');
         """
         logger.info(f"Table registration with : \n{create_table_query} \n")
+    elif output_info['type'] == 'parquet':
+        create_table_query = f"""
+            CREATE EXTERNAL TABLE IF NOT EXISTS `{schema}`.`{name_tb}` (
+            {types_str}
+            ) {description_statement}
+            STORED AS PARQUET
+            LOCATION '{output_folder}'
+        """
+        logger.info(f"Table registration with : \n{create_table_query} \n")
     else:
         raise Exception('Athena table registration not setup for other than csv files.')
 

--- a/yaetos/athena.py
+++ b/yaetos/athena.py
@@ -45,9 +45,7 @@ def register_table(types, name_tb, schema, output_info, args):
         config = ConfigParser()
         assert os.path.isfile(args.get('aws_config_file'))
         config.read(args.get('aws_config_file'))
-        # profile_name = config.get(args.get('aws_setup'), 'profile_name')
         region_name = config.get(args.get('aws_setup'), 's3_region')
-        # region_name = boto3.Session(profile_name=profile_name).region_name
     else:
         region_name = boto3.Session().region_name
 

--- a/yaetos/athena.py
+++ b/yaetos/athena.py
@@ -4,9 +4,8 @@ from yaetos.logger import setup_logging
 logger = setup_logging('Athena')
 
 
-def register_table(types, name_tb, schema, output_info, creds_or_file, description=None):
+def register_table(types, name_tb, schema, output_info, description=None):
     # TODO: Check to support "is_incremental"
-    description = 'some description'
     description_statement = f'COMMENT "{description}"' if description else ''
     output_folder = output_info['path_expanded'].replace('s3a', 's3')
     query_folder = 's3://mylake-dev/pipelines_data/athena_data/'

--- a/yaetos/athena.py
+++ b/yaetos/athena.py
@@ -29,7 +29,7 @@ def register_table(types, name_tb, schema, output_info, args):
         """
         logger.info(f"Table registration with : \n{create_table_query} \n")
     else:
-        raise Exception('Athena table registration not setup for other than csv files.')    
+        raise Exception('Athena table registration not setup for other than csv files.')
 
     # Start the query execution
     if args.get('mode') == 'dev_local':
@@ -50,4 +50,3 @@ def register_table(types, name_tb, schema, output_info, args):
     )
     logger.info(f"Registered table to athena '{schema}.{name_tb}', with QueryExecutionId: {response['QueryExecutionId']}.")
     # TODO: Check to support "is_incremental"
-

--- a/yaetos/db_utils.py
+++ b/yaetos/db_utils.py
@@ -110,10 +110,11 @@ def pdf_to_sdf(df, output_types, sc, sc_sql):  # TODO: check suspicion that this
 
     return sc_sql.createDataFrame(rdd, schema=spark_schema, verifySchema=True)
 
+
 def pandas_types_to_hive_types(df):
     """
     Converts pandas DataFrame dtypes to Hive column types.
-    
+
     :param df: pandas DataFrame
     :return: Dictionary of column names and their Hive data types
     """
@@ -123,7 +124,7 @@ def pandas_types_to_hive_types(df):
         'datetime64[ns]': 'TIMESTAMP',
         'timedelta[ns]': 'STRING',  # Hive does not have a direct equivalent
         'category': 'STRING',  # Hive has no direct category type; consider using STRING or a specific type based on the category
-        
+
         # Integer types
         'int8': 'TINYINT',
         'int16': 'SMALLINT',
@@ -133,12 +134,12 @@ def pandas_types_to_hive_types(df):
         'uint16': 'INT',
         'uint32': 'BIGINT',
         'uint64': 'BIGINT',  # Note: Hive BIGINT might not cover the full range of uint64
-        
+
         # Floating types
         'float16': 'FLOAT',
         'float32': 'FLOAT',
         'float64': 'DOUBLE',
-        
+
         # Special handling for decimals
         # This is a placeholder; actual handling should consider the specific precision and scale
         # 'decimal': 'DECIMAL',

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -620,7 +620,8 @@ class ETL_Base(object):
         pdf = df if isinstance(df, pd.DataFrame) else df.toPandas()
         hive_types = pandas_types_to_hive_types(pdf)
         description = self.jargs.merged_args.get('table_description')
-        register_table(hive_types, name_tb, schema, output_info, description)
+        args = self.jargs.merged_args
+        register_table(hive_types, name_tb, schema, output_info, args)
 
     def copy_to_clickhouse(self, sdf):
         # import put here below to avoid loading heavy libraries when not needed (optional feature).

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -619,7 +619,6 @@ class ETL_Base(object):
         output_info = self.jargs.output
         pdf = df if isinstance(df, pd.DataFrame) else df.toPandas()
         hive_types = pandas_types_to_hive_types(pdf)
-        description = self.jargs.merged_args.get('table_description')
         args = self.jargs.merged_args
         register_table(hive_types, name_tb, schema, output_info, args)
 

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -614,15 +614,13 @@ class ETL_Base(object):
     def register_to_athena(self, df):
         from yaetos.athena import register_table
         from yaetos.db_utils import pandas_types_to_hive_types
-        # connection_profile = self.jargs.copy_to_redshift['creds']
         schema, name_tb = self.jargs.register_to_athena['table'].split('.')
         schema = schema.format(schema=self.jargs.schema) if '{schema}' in schema else schema
         creds = Cred_Ops_Dispatcher().retrieve_secrets(self.jargs.storage, aws_creds=AWS_SECRET_ID, local_creds=self.jargs.connection_file)
         output_info = self.jargs.output
         pdf = df if isinstance(df, pd.DataFrame) else df.toPandas()
         hive_types = pandas_types_to_hive_types(pdf)
-        # import ipdb; ipdb.set_trace()
-        register_table(hive_types, name_tb, schema, output_info, creds, self.jargs.is_incremental)
+        register_table(hive_types, name_tb, schema, output_info, creds)
 
     def copy_to_clickhouse(self, sdf):
         # import put here below to avoid loading heavy libraries when not needed (optional feature).

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -616,11 +616,11 @@ class ETL_Base(object):
         from yaetos.db_utils import pandas_types_to_hive_types
         schema, name_tb = self.jargs.register_to_athena['table'].split('.')
         schema = schema.format(schema=self.jargs.schema) if '{schema}' in schema else schema
-        creds = Cred_Ops_Dispatcher().retrieve_secrets(self.jargs.storage, aws_creds=AWS_SECRET_ID, local_creds=self.jargs.connection_file)
         output_info = self.jargs.output
         pdf = df if isinstance(df, pd.DataFrame) else df.toPandas()
         hive_types = pandas_types_to_hive_types(pdf)
-        register_table(hive_types, name_tb, schema, output_info, creds)
+        description = self.jargs.merged_args.get('table_description')
+        register_table(hive_types, name_tb, schema, output_info, description)
 
     def copy_to_clickhouse(self, sdf):
         # import put here below to avoid loading heavy libraries when not needed (optional feature).

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -179,13 +179,13 @@ class ETL_Base(object):
             schemas.save_yaml(self.jargs.job_name)
         # self.save_metadata(elapsed)  # disable for now to avoid spark parquet reading issues. TODO: check to re-enable.
 
-        if self.jargs.merged_args.get('copy_to_redshift') and self.jargs.enable_redshift_push:
+        if self.jargs.merged_args.get('copy_to_redshift') and self.jargs.enable_db_push:
             self.copy_to_redshift_using_spark(output)  # to use pandas: self.copy_to_redshift_using_pandas(output, self.OUTPUT_TYPES)
-        if self.jargs.merged_args.get('copy_to_clickhouse') and self.jargs.enable_redshift_push:  # TODO: rename enable_redshift_push to enable_db_push since not redshift here.
+        if self.jargs.merged_args.get('copy_to_clickhouse') and self.jargs.enable_db_push:  # TODO: rename enable_db_push to enable_db_push since not redshift here.
             self.copy_to_clickhouse(output)
         if self.jargs.merged_args.get('copy_to_kafka'):
             self.push_to_kafka(output, self.OUTPUT_TYPES)
-        if self.jargs.merged_args.get('register_to_athena') and self.jargs.enable_redshift_push:
+        if self.jargs.merged_args.get('register_to_athena') and self.jargs.enable_db_push:
             self.register_to_athena(output)
             # import ipdb; ipdb.set_trace()
 
@@ -1054,7 +1054,7 @@ class Runner():
             'leave_on': False,  # will be overriden by default in cmdline arg unless cmdline args disabled (ex: unitests)
             'push_secrets': False,  # will be overriden by default in cmdline arg unless cmdline args disabled (ex: unitests)
             # -- Not added in command line args:
-            'enable_redshift_push': True,
+            'enable_db_push': True,
             'base_path': '',
             'save_schemas': False,
             'manage_git_info': False,
@@ -1063,7 +1063,7 @@ class Runner():
             'spark_boot': True,  # options ('spark', 'pandas') (experimental).
             # 'dry_run': False,
         }
-        redshift = ['enable_redshift_push', 'schema', 'redshift_s3_tmp_dir', 'redshift_s3_tmp_dir']
+        redshift = ['enable_db_push', 'schema', 'redshift_s3_tmp_dir', 'redshift_s3_tmp_dir']
         spark = ['no_fw_cache', 'spark_boot', 'spark_version']
         aws = ['aws_config_file', 'aws_setup', 'emr_core_instances', 'jobs_folder', 'push_secrets', 'ec2_instance_master', 'ec2_instance_slaves']
         emr_deploy = ['leave_on'] + aws

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1114,7 +1114,7 @@ class Runner():
 
     @staticmethod
     def create_spark_submit(jargs):
-        # TODO: refactor that code to avoid repetition.
+        # TODO: refactor code below to avoid repetition.
         launcher_file = jargs.merged_args.get('jar_job') or jargs.merged_args['py_job']
 
         spark_submit_cmd = ["spark-submit"]

--- a/yaetos/scripts/copy/jobs_metadata_external.yml
+++ b/yaetos/scripts/copy/jobs_metadata_external.yml
@@ -77,7 +77,7 @@ common_params:
       aws_setup:        pro
       jobs_folder:      jobs/
       load_connectors: all
-      enable_redshift_push: True
+      enable_db_push: True
       save_schemas: False
       manage_git_info: True
     dev_EMR:
@@ -88,7 +88,7 @@ common_params:
       aws_setup:        dev
       jobs_folder:      jobs/
       load_connectors: all
-      enable_redshift_push: False
+      enable_db_push: False
       save_schemas: False
       manage_git_info: True
     dev_local:
@@ -97,6 +97,6 @@ common_params:
       schema: sandbox
       load_connectors: none
       aws_config_file:  none
-      enable_redshift_push: False
+      enable_db_push: False
       save_schemas: True
       manage_git_info: False


### PR DESCRIPTION
New feature to register tables to Athena, as part of jobs_metadata.yml, using param `register_to_athena: {'table': 'some_schema.some_table'}`
 * tested with new demo job ´example/ex13_register_athena_job´
 * supports only csv and parquet for now

Other:
 * rename `enable_redshift_push´ to ´enable_db_push´