### PR TITLE
Json + multipath loading + glob

### DIFF
--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -307,12 +307,12 @@ jobs:
     spark_boot: False
 
   examples/ex15_copy_job_multi_path.py:
+    description: "Job to demo loading datasets with the same schemas spread over various folders, following structured path. The job will go through combinations of category and subcategory params defined below to extract datasets."
     inputs:
       table_to_copy: {'path':"tests/fixtures/data_sample/wiki_example/input_multipath/{category}/{subcategory}/dataset.csv", 'type':'csv', 'df_type':'pandas', 'load':False}
     output: {'path':'{base_path}/load_example/multipath/{category}/{subcategory}/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas'}
     category: ['catA', 'catB']
     subcategory: ['subcatA', 'subcatB']
-    # looping: ['category', 'subcategory']
     spark_boot: False
 
   examples/ex16_glob_load_job:

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -285,6 +285,19 @@ jobs:
     athena_out: s3://mylake-dev/pipelines_data/athena_data/
     load_connectors: all
 
+  examples/ex14_json_format1_load_job:
+    py_job: jobs/generic/copy_job.py
+    inputs:
+      table_to_copy: {'path':"tests/fixtures/data_sample/wiki_example/input_json_format1/dataset.json", 'type':'json', 'df_type':'pandas', 'read_kwargs':{'lines':True}}
+    output: {'path':'{base_path}/load_example/json_format1/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas'}
+    spark_boot: False
+
+  examples/ex14_json_format2_load_job:
+    py_job: jobs/generic/copy_job.py
+    inputs:
+      table_to_copy: {'path':"tests/fixtures/data_sample/wiki_example/input_json_format2/dataset.json", 'type':'json', 'df_type':'pandas'}
+    output: {'path':'{base_path}/load_example/json_format2/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas'}
+    spark_boot: False
   # wordcount_raw_job: #Job exists but doesn't rely on jobs_metadata entries
 
   # ----- Marketing Jobs --------

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -298,6 +298,14 @@ jobs:
       table_to_copy: {'path':"tests/fixtures/data_sample/wiki_example/input_json_format2/dataset.json", 'type':'json', 'df_type':'pandas'}
     output: {'path':'{base_path}/load_example/json_format2/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas'}
     spark_boot: False
+
+  examples/ex16_glob_load_job:
+    py_job: jobs/generic/copy_job.py
+    inputs:
+      table_to_copy: {'path':"tests/fixtures/data_sample/wiki_example/input/", 'type':'csv', 'glob':'part1*', 'df_type':'pandas'}
+    output: {'path':'{base_path}/load_example/glob_filtering/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas'}
+    spark_boot: False
+
   # wordcount_raw_job: #Job exists but doesn't rely on jobs_metadata entries
 
   # ----- Marketing Jobs --------

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -299,6 +299,13 @@ jobs:
     output: {'path':'{base_path}/load_example/json_format2/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas'}
     spark_boot: False
 
+  examples/ex14_json_format3_load_job:
+    py_job: jobs/generic/copy_job.py
+    inputs:
+      table_to_copy: {'path':"tests/fixtures/data_sample/wiki_example/input_json_format3/dataset.json", 'type':'json', 'df_type':'json_pandas'}
+    output: {'path':'{base_path}/load_example/json_format3/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas'}
+    spark_boot: False
+
   examples/ex16_glob_load_job:
     py_job: jobs/generic/copy_job.py
     inputs:

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -306,6 +306,15 @@ jobs:
     output: {'path':'{base_path}/load_example/json_format3/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas'}
     spark_boot: False
 
+  examples/ex15_copy_job_multi_path.py:
+    inputs:
+      table_to_copy: {'path':"tests/fixtures/data_sample/wiki_example/input_multipath/{category}/{subcategory}/dataset.csv", 'type':'csv', 'df_type':'pandas', 'load':False}
+    output: {'path':'{base_path}/load_example/multipath/{category}/{subcategory}/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas'}
+    category: ['catA', 'catB']
+    subcategory: ['subcatA', 'subcatB']
+    # looping: ['category', 'subcategory']
+    spark_boot: False
+
   examples/ex16_glob_load_job:
     py_job: jobs/generic/copy_job.py
     inputs:

--- a/jobs/examples/ex15_copy_job_multi_path.py
+++ b/jobs/examples/ex15_copy_job_multi_path.py
@@ -1,4 +1,7 @@
 from yaetos.etl_utils import ETL_Base, Commandliner, Path_Handler
+# Improvements: 
+# - make that job generic, by adding a para 'looping': ['category', 'subcategory'] , in jobs_metadata.yml and using it below.
+
 
 
 class Job(ETL_Base):
@@ -29,6 +32,7 @@ class Job(ETL_Base):
         return None
 
     def transform_one(self, table_to_copy):
+        "Generic for spark and pandas, although this job is pandas only for now."
         if self.jargs.output.get('df_type', 'spark') == 'spark':
             table_to_copy.cache()
             if table_to_copy.count() < 500000:
@@ -47,8 +51,6 @@ class Job(ETL_Base):
     def expand_output_path(self, path, now_dt, **kwargs):
         category = kwargs['category']
         subcategory = kwargs['subcategory']
-        # base_path_expanded = self.jargs.base_path.replace('{region}', region)
-        # base_path_expanded = self.jargs.base_path.replace('{region}', region)
         base_path = self.jargs.base_path
         path_partly_expanded = path.replace('{category}', category) \
                                    .replace('{subcategory}', subcategory)

--- a/jobs/examples/ex15_copy_job_multi_path.py
+++ b/jobs/examples/ex15_copy_job_multi_path.py
@@ -1,7 +1,6 @@
 from yaetos.etl_utils import ETL_Base, Commandliner, Path_Handler
-# Improvements: 
+# Improvements:
 # - make that job generic, by adding a para 'looping': ['category', 'subcategory'] , in jobs_metadata.yml and using it below.
-
 
 
 class Job(ETL_Base):
@@ -15,7 +14,7 @@ class Job(ETL_Base):
                 name = 'table_to_copy'
                 path_raw = self.jargs.inputs['table_to_copy']['path']
                 type = self.jargs.inputs['table_to_copy']['type']
-                sc, sc_sql = None, None 
+                sc, sc_sql = None, None
                 df_meta = self.jargs.inputs['table_to_copy']
                 kwargs = {}
                 kwargs['category'] = category

--- a/jobs/examples/ex15_copy_job_multi_path.py
+++ b/jobs/examples/ex15_copy_job_multi_path.py
@@ -4,7 +4,6 @@ from yaetos.etl_utils import ETL_Base, Commandliner, Path_Handler
 
 
 class Job(ETL_Base):
-
     def transform(self, table_to_copy):
         for category in self.jargs.category:
             for subcategory in self.jargs.subcategory:

--- a/jobs/examples/ex15_copy_job_multi_path.py
+++ b/jobs/examples/ex15_copy_job_multi_path.py
@@ -1,0 +1,61 @@
+from yaetos.etl_utils import ETL_Base, Commandliner, Path_Handler
+
+
+class Job(ETL_Base):
+
+    def transform(self, table_to_copy):
+        for category in self.jargs.category:
+            for subcategory in self.jargs.subcategory:
+                self.logger.info(f"--- About to process category={category}, subcategory={subcategory} ---")
+
+                # params
+                name = 'table_to_copy'
+                path_raw = self.jargs.inputs['table_to_copy']['path']
+                type = self.jargs.inputs['table_to_copy']['type']
+                sc, sc_sql = None, None 
+                df_meta = self.jargs.inputs['table_to_copy']
+                kwargs = {}
+                kwargs['category'] = category
+                kwargs['subcategory'] = subcategory
+                path_raw_out = self.jargs.output['path']
+                base_path = self.jargs.base_path
+                type_out = self.jargs.output['type']
+
+                # transfo
+                df_in = self.load_data_from_files(name, path_raw, type, sc, sc_sql, df_meta, **kwargs)
+                df_out = self.transform_one(df_in)
+                self.save(df_out, path_raw_out, base_path, type_out, now_dt=self.start_dt, is_incremental=None, incremental_type=None, partitionby=None, file_tag=None, **kwargs)
+
+        return None
+
+    def transform_one(self, table_to_copy):
+        if self.jargs.output.get('df_type', 'spark') == 'spark':
+            table_to_copy.cache()
+            if table_to_copy.count() < 500000:
+                table_to_copy = table_to_copy.repartition(1)
+        return table_to_copy
+
+    def expand_input_path(self, path, **kwargs):
+        category = kwargs['category']
+        subcategory = kwargs['subcategory']
+        base_path = self.jargs.base_path
+        path_partly_expanded = path.replace('{category}', category) \
+                                   .replace('{subcategory}', subcategory)
+        path = Path_Handler(path_partly_expanded, base_path, self.jargs.merged_args.get('root_path')).expand_later()
+        return path
+
+    def expand_output_path(self, path, now_dt, **kwargs):
+        category = kwargs['category']
+        subcategory = kwargs['subcategory']
+        # base_path_expanded = self.jargs.base_path.replace('{region}', region)
+        # base_path_expanded = self.jargs.base_path.replace('{region}', region)
+        base_path = self.jargs.base_path
+        path_partly_expanded = path.replace('{category}', category) \
+                                   .replace('{subcategory}', subcategory)
+        path = Path_Handler(path_partly_expanded, base_path, self.jargs.merged_args.get('root_path')).expand_now(now_dt)
+        return path
+
+
+if __name__ == "__main__":
+    args = {'job_param_file': 'conf/jobs_metadata.yml'}
+    Commandliner(Job, **args)

--- a/tests/fixtures/data_sample/wiki_example/input_json_format1/dataset.json
+++ b/tests/fixtures/data_sample/wiki_example/input_json_format1/dataset.json
@@ -1,0 +1,3 @@
+{"uuid":"u1","timestamp":2.0,"session_id":"s1","group":"g1","action":"searchResultPage","checkin":"NaN", "page_id":"p1","n_results":5.0, "result_position":null}
+{"uuid":"u2","timestamp":2.0,"session_id":"s2","group":"g2","action":"searchResultPage","checkin":"NaN", "page_id":"p2","n_results":9.0, "result_position":null}
+{"uuid":"u3","timestamp":2.0,"session_id":"s3","group":"g3","action":"checkin"         ,"checkin":"30.0","page_id":"p3","n_results":null,"result_position":null}

--- a/tests/fixtures/data_sample/wiki_example/input_json_format2/dataset.json
+++ b/tests/fixtures/data_sample/wiki_example/input_json_format2/dataset.json
@@ -1,0 +1,5 @@
+[
+{"uuid":"u1","timestamp":2.0,"session_id":"s1","group":"g1","action":"searchResultPage","checkin":"NaN", "page_id":"p1","n_results":5.0, "result_position":null},
+{"uuid":"u2","timestamp":2.0,"session_id":"s2","group":"g2","action":"searchResultPage","checkin":"NaN", "page_id":"p2","n_results":9.0, "result_position":null},
+{"uuid":"u3","timestamp":2.0,"session_id":"s3","group":"g3","action":"checkin"         ,"checkin":"30.0","page_id":"p3","n_results":null,"result_position":null}
+]

--- a/tests/fixtures/data_sample/wiki_example/input_json_format3/dataset.json
+++ b/tests/fixtures/data_sample/wiki_example/input_json_format3/dataset.json
@@ -1,0 +1,9 @@
+{
+    "records":
+    [
+        {"uuid":"u1","timestamp":2.0,"session_id":"s1","group":"g1","action":"searchResultPage","checkin":"NaN", "page_id":"p1","n_results":5.0, "result_position":null},
+        {"uuid":"u2","timestamp":2.0,"session_id":"s2","group":"g2","action":"searchResultPage","checkin":"NaN", "page_id":"p2","n_results":9.0, "result_position":null},
+        {"uuid":"u3","timestamp":2.0,"session_id":"s3","group":"g3","action":"checkin"         ,"checkin":"30.0","page_id":"p3","n_results":null,"result_position":null}
+    ]
+        
+}

--- a/tests/fixtures/data_sample/wiki_example/input_multipath/catA/subcatA/dataset.csv
+++ b/tests/fixtures/data_sample/wiki_example/input_multipath/catA/subcatA/dataset.csv
@@ -1,0 +1,5 @@
+uuid,timestamp,session_id,group,action,checkin,page_id,n_results,result_position
+u1,2.0,s1,g1,searchResultPage,NaN,p1,5.0,NaN
+u2,2.0,s2,g2,searchResultPage,NaN,p2,9.0,NaN
+u3,2.0,s3,g3,checkin,30.0,p3,NaN,NaN
+

--- a/tests/fixtures/data_sample/wiki_example/input_multipath/catA/subcatB/dataset.csv
+++ b/tests/fixtures/data_sample/wiki_example/input_multipath/catA/subcatB/dataset.csv
@@ -1,0 +1,5 @@
+uuid,timestamp,session_id,group,action,checkin,page_id,n_results,result_position
+u1,2.0,s1,g1,searchResultPage,NaN,p1,5.0,NaN
+u2,2.0,s2,g2,searchResultPage,NaN,p2,9.0,NaN
+u3,2.0,s3,g3,checkin,30.0,p3,NaN,NaN
+

--- a/tests/fixtures/data_sample/wiki_example/input_multipath/catB/subcatA/dataset.csv
+++ b/tests/fixtures/data_sample/wiki_example/input_multipath/catB/subcatA/dataset.csv
@@ -1,0 +1,5 @@
+uuid,timestamp,session_id,group,action,checkin,page_id,n_results,result_position
+u1,2.0,s1,g1,searchResultPage,NaN,p1,5.0,NaN
+u2,2.0,s2,g2,searchResultPage,NaN,p2,9.0,NaN
+u3,2.0,s3,g3,checkin,30.0,p3,NaN,NaN
+

--- a/tests/fixtures/data_sample/wiki_example/input_multipath/catB/subcatB/dataset.csv
+++ b/tests/fixtures/data_sample/wiki_example/input_multipath/catB/subcatB/dataset.csv
@@ -1,0 +1,5 @@
+uuid,timestamp,session_id,group,action,checkin,page_id,n_results,result_position
+u1,2.0,s1,g1,searchResultPage,NaN,p1,5.0,NaN
+u2,2.0,s2,g2,searchResultPage,NaN,p2,9.0,NaN
+u3,2.0,s3,g3,checkin,30.0,p3,NaN,NaN
+

--- a/tests/yaetos/pandas_utils_test.py
+++ b/tests/yaetos/pandas_utils_test.py
@@ -2,7 +2,7 @@ import os
 from pandas.testing import assert_frame_equal
 import pandas as pd
 import numpy as np
-from yaetos.pandas_utils import load_csvs, load_df, save_pandas_local
+from yaetos.pandas_utils import load_csvs, load_dfs, save_pandas_local
 # TODO: check to remove .reset_index(drop=True), using assert_frame_equal(d1, d2, check_index_type=False) instead
 
 
@@ -31,10 +31,10 @@ def test_load_csvs():
     assert_frame_equal(actual, expected)
 
 
-def test_load_df():
+def test_load_dfs():
     # Test multiple file option
     path = 'tests/fixtures/data_sample/wiki_example/input/'
-    actual = load_df(path, file_type='csv', read_func='read_csv', read_kwargs={}).sort_values('uuid').reset_index(drop=True)
+    actual = load_dfs(path, file_type='csv', read_func='read_csv', read_kwargs={}).sort_values('uuid').reset_index(drop=True)
     expected = pd.DataFrame([
         {'uuid': 'u1', 'timestamp': 2.0, 'session_id': 's1', 'group': 'g1', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p1', 'n_results': 5.0, 'result_position': np.nan, '_source': 'tests/fixtures/data_sample/wiki_example/input/part1.csv'},
         {'uuid': 'u2', 'timestamp': 2.0, 'session_id': 's2', 'group': 'g2', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p2', 'n_results': 9.0, 'result_position': np.nan, '_source': 'tests/fixtures/data_sample/wiki_example/input/part1.csv'},
@@ -47,7 +47,7 @@ def test_load_df():
 
     # Test single file option, csv
     path = 'tests/fixtures/data_sample/wiki_example/input/part1.csv'
-    actual = load_df(path, file_type='csv', read_func='read_csv', read_kwargs={}).reset_index(drop=True)
+    actual = load_dfs(path, file_type='csv', read_func='read_csv', read_kwargs={}).reset_index(drop=True)
     expected = pd.DataFrame([
         {'uuid': 'u1', 'timestamp': 2.0, 'session_id': 's1', 'group': 'g1', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p1', 'n_results': 5.0, 'result_position': np.nan},
         {'uuid': 'u2', 'timestamp': 2.0, 'session_id': 's2', 'group': 'g2', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p2', 'n_results': 9.0, 'result_position': np.nan},
@@ -57,7 +57,7 @@ def test_load_df():
 
     # Test single file option, parquet
     path = 'tests/fixtures/data_sample/wiki_example/input_parquet/part1.parquet'
-    actual = load_df(path, file_type='parquet', read_func='read_parquet', read_kwargs={}).reset_index(drop=True)
+    actual = load_dfs(path, file_type='parquet', read_func='read_parquet', read_kwargs={}).reset_index(drop=True)
     expected = pd.DataFrame([
         {'uuid': 'u1', 'timestamp': 2.0, 'session_id': 's1', 'group': 'g1', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p1', 'n_results': 5.0, 'result_position': np.nan},
         {'uuid': 'u2', 'timestamp': 2.0, 'session_id': 's2', 'group': 'g2', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p2', 'n_results': 9.0, 'result_position': np.nan},
@@ -67,7 +67,7 @@ def test_load_df():
 
     # Test single file option, excel
     path = 'tests/fixtures/data_sample/wiki_example/input_excel/parts.xlsx'
-    actual = load_df(path, file_type='xlsx', read_func='read_excel', read_kwargs={'engine': 'openpyxl', 'sheet_name': 0, 'header': 1}).reset_index(drop=True)
+    actual = load_dfs(path, file_type='xlsx', read_func='read_excel', read_kwargs={'engine': 'openpyxl', 'sheet_name': 0, 'header': 1}).reset_index(drop=True)
     expected = pd.DataFrame([
         {'uuid': 'u1', 'timestamp': 2, 'session_id': 's1', 'group': 'g1', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p1', 'n_results': 5.0, 'result_position': np.nan},
         {'uuid': 'u2', 'timestamp': 2, 'session_id': 's2', 'group': 'g2', 'action': 'searchResultPage', 'checkin': np.nan, 'page_id': 'p2', 'n_results': 9.0, 'result_position': np.nan},

--- a/yaetos/env_dispatchers.py
+++ b/yaetos/env_dispatchers.py
@@ -146,9 +146,10 @@ class FS_Ops_Dispatcher():
     def load_pandas_cluster(self, fname, file_type, read_func, read_kwargs):
         # import put here below to avoid loading it when working in local only.
         from cloudpathlib import CloudPath
+        import uuid
 
         bucket_name, bucket_fname, fname_parts = self.split_s3_path(fname)
-        local_path = 'tmp/s3_copy_' + fname_parts[-1]
+        local_path = 'tmp/s3_copy_' + fname_parts[-1] + '_' + str(uuid.uuid4())
         cp = CloudPath(fname)  # TODO: add way to load it with specific profile_name or client, as in "s3c = boto3.Session(profile_name='default').client('s3')"
         logger.info("Copying files from S3 '{}' to local '{}'. May take some time.".format(fname, local_path))
         local_pathlib = cp.download_to(local_path)

--- a/yaetos/env_dispatchers.py
+++ b/yaetos/env_dispatchers.py
@@ -7,7 +7,7 @@ from time import sleep
 from io import StringIO
 # from sklearn.externals import joblib  # TODO: re-enable after fixing lib versions.
 from configparser import ConfigParser
-from yaetos.pandas_utils import load_df, save_pandas_local
+from yaetos.pandas_utils import load_dfs, save_pandas_local
 from yaetos.logger import setup_logging
 logger = setup_logging('Job')
 
@@ -155,7 +155,7 @@ class FS_Ops_Dispatcher():
         local_pathlib = cp.download_to(local_path)
         local_path = local_path + '/' if local_pathlib.is_dir() else local_path
         logger.info("File copy finished")
-        df = load_df(local_path, file_type, read_func, read_kwargs)
+        df = load_dfs(local_path, file_type, globy, read_func, read_kwargs)
         return df
 
     # --- save_pandas set of functions ----

--- a/yaetos/env_dispatchers.py
+++ b/yaetos/env_dispatchers.py
@@ -152,15 +152,13 @@ class FS_Ops_Dispatcher():
         local_path = 'tmp/s3_copy_' + fname_parts[-1] + '_' + str(uuid.uuid4())
         cp = CloudPath(fname)  # TODO: add way to load it with specific profile_name or client, as in "s3c = boto3.Session(profile_name='default').client('s3')"
         if globy:
-            logger.info(f"### Test '{globy}'")
             cfiles = cp.glob(globy)
             os.makedirs(local_path, exist_ok=True)
-            #import ipdb; ipdb.set_trace()
+            logger.info(f"Copying {len(cfile)} files from S3 to local '{local_path}'")
             for cfile in cfiles:
                 local_file_path = os.path.join(local_path, cfile.name)
                 local_pathlib = cfile.download_to(local_file_path)
-                logger.info(f"Copying files from S3 '{cfile}' to local '{local_file_path}'")
-                local_path += '/'
+            local_path += '/'
         else:
             logger.info("Copying files from S3 '{}' to local '{}'. May take some time.".format(fname, local_path))
             local_pathlib = cp.download_to(local_path)

--- a/yaetos/env_dispatchers.py
+++ b/yaetos/env_dispatchers.py
@@ -154,7 +154,7 @@ class FS_Ops_Dispatcher():
         if globy:
             cfiles = cp.glob(globy)
             os.makedirs(local_path, exist_ok=True)
-            logger.info(f"Copying {len(cfile)} files from S3 to local '{local_path}'")
+            logger.info(f"Copying {len(cfiles)} files from S3 to local '{local_path}'")
             for cfile in cfiles:
                 local_file_path = os.path.join(local_path, cfile.name)
                 local_pathlib = cfile.download_to(local_file_path)

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -256,7 +256,7 @@ class ETL_Base(object):
                 continue
 
             # Skip "other" types
-            if self.jargs.inputs[item]['type'] == "other" or self.jargs.inputs[item].get('load') == False:
+            if self.jargs.inputs[item]['type'] == "other" or self.jargs.inputs[item].get('load') is False:
                 app_args[item] = None
                 logger.info("Input '{}' not loaded since type set to 'other' or used load=False flag.".format(item))
                 continue
@@ -403,13 +403,12 @@ class ETL_Base(object):
         """Loading any dataset (input or not) and only from file system (not from DBs). Used by incremental jobs to load previous output.
         Different from load_input() which only loads input (input jargs hardcoded) and from any source."""
         # TODO: integrate with load_input to remove duplicated code.
-        input_type = type  # TODO: remove 'input_' prefix in code below since not specific to input. 
+        input = df_meta  # TODO: get 2 variables below from this one.
+        input_type = type  # TODO: remove 'input_' prefix in code below since not specific to input.
         input_name = name
-        input = df_meta  # TODO: get 2 variables above from this one.
         path = path.replace('s3://', 's3a://') if self.jargs.mode == 'dev_local' else path
         logger.info("Dataset '{}' to be loaded from files '{}'.".format(input_name, path))
         path = self.expand_input_path(path, **kwargs)
-        input['path_expanded'] = path
 
         # Unstructured type
         if input_type == 'txt':

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -347,17 +347,19 @@ class ETL_Base(object):
             return rdd
 
         # Tabular, Pandas
+        # TODO: move block to pandas_util.py
         if self.jargs.inputs[input_name].get('df_type') == 'pandas':
+            globy = self.jargs.inputs[input_name].get('glob')
             if input_type == 'csv':
-                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='csv', read_func='read_csv', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
+                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='csv', globy=globy, read_func='read_csv', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
             elif input_type == 'parquet':
-                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='parquet', read_func='read_parquet', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
+                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='parquet', globy=globy, read_func='read_parquet', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
             elif input_type == 'json':
                 pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='json', globy=globy, read_func='read_json', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
             elif input_type == 'xlsx':
-                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='xlsx', read_func='read_excel', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
+                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='xlsx', globy=globy, read_func='read_excel', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
             elif input_type == 'xls':
-                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='xls', read_func='read_excel', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
+                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='xls', globy=globy, read_func='read_excel', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
             else:
                 raise Exception("Unsupported input type '{}' for path '{}'. Supported types for pandas are: {}. ".format(input_type, self.jargs.inputs[input_name].get('path'), self.PANDAS_DF_TYPES))
             logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -409,7 +409,6 @@ class ETL_Base(object):
         path = path.replace('s3://', 's3a://') if self.jargs.mode == 'dev_local' else path
         logger.info("Dataset '{}' to be loaded from files '{}'.".format(input_name, path))
         path = self.expand_input_path(path, **kwargs)
-        # path = Path_Handler(path, self.jargs.base_path, self.jargs.merged_args.get('root_path')).expand_later()
         input['path_expanded'] = path
 
         # Unstructured type
@@ -435,7 +434,7 @@ class ETL_Base(object):
             else:
                 raise Exception("Unsupported input type '{}' for path '{}'. Supported types for pandas are: {}. ".format(input_type, input.get('path'), self.PANDAS_DF_TYPES))
             logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
-            # logger.info("Input data types: {}".format(pformat([(fd.name, fd.dataType) for fd in sdf.schema.fields])))  # TODO adapt to pandas
+            # TODO: add equ for pandas : logger.info("Input data types: {}".format(pformat([(fd.name, fd.dataType) for fd in sdf.schema.fields])))
             return pdf
 
         # Tabular types, Spark

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -256,9 +256,9 @@ class ETL_Base(object):
                 continue
 
             # Skip "other" types
-            if self.jargs.inputs[item]['type'] == "other":
+            if self.jargs.inputs[item]['type'] == "other" or self.jargs.inputs[item].get('load') == False:
                 app_args[item] = None
-                logger.info("Input '{}' not loaded since type set to 'other'.".format(item))
+                logger.info("Input '{}' not loaded since type set to 'other' or used load=False flag.".format(item))
                 continue
 
             # Load from disk

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -51,10 +51,10 @@ JARS = 'https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.13/redshi
 
 
 class ETL_Base(object):
-    TABULAR_TYPES = ('csv', 'parquet', 'xlsx', 'xls', 'df', 'mysql', 'clickhouse')
-    SPARK_DF_TYPES = ('csv', 'parquet', 'xlsx', 'xls', 'df', 'mysql', 'clickhouse')
-    PANDAS_DF_TYPES = ('csv', 'parquet', 'xlsx', 'xls', 'df')
-    FILE_TYPES = ('csv', 'parquet', 'xlsx', 'xls', 'txt')
+    TABULAR_TYPES = ('csv', 'parquet', 'json', 'xlsx', 'xls', 'df', 'mysql', 'clickhouse')
+    SPARK_DF_TYPES = ('csv', 'parquet', 'json', 'xlsx', 'xls', 'df', 'mysql', 'clickhouse')
+    PANDAS_DF_TYPES = ('csv', 'parquet', 'json', 'xlsx', 'xls', 'df')
+    FILE_TYPES = ('csv', 'parquet', 'json', 'xlsx', 'xls', 'txt')
     OTHER_TYPES = ('other', 'None')
     SUPPORTED_TYPES = set(TABULAR_TYPES) \
         .union(set(SPARK_DF_TYPES)) \
@@ -352,6 +352,8 @@ class ETL_Base(object):
                 pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='csv', read_func='read_csv', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
             elif input_type == 'parquet':
                 pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='parquet', read_func='read_parquet', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
+            elif input_type == 'json':
+                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='json', globy=globy, read_func='read_json', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
             elif input_type == 'xlsx':
                 pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='xlsx', read_func='read_excel', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
             elif input_type == 'xls':
@@ -369,6 +371,9 @@ class ETL_Base(object):
             logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
         elif input_type == 'parquet':
             sdf = self.sc_sql.read.parquet(path)
+            logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
+        elif input_type == 'json':
+            sdf = self.sc_sql.read.json(path)
             logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
         elif input_type == 'mysql':
             sdf = self.load_mysql(input_name)
@@ -544,6 +549,8 @@ class ETL_Base(object):
                 FS_Ops_Dispatcher().save_pandas(output, path, save_method='to_csv', save_kwargs=self.jargs.output.get('save_kwargs', {}))
             elif type == 'parquet':
                 FS_Ops_Dispatcher().save_pandas(output, path, save_method='to_parquet', save_kwargs=self.jargs.output.get('save_kwargs', {}))
+            elif type == 'json':
+                FS_Ops_Dispatcher().save_pandas(output, path, save_method='to_json', save_kwargs=self.jargs.output.get('save_kwargs', {}))
             elif type in ('xlsx', 'xls'):
                 FS_Ops_Dispatcher().save_pandas(output, path, save_method='to_excel', save_kwargs=self.jargs.output.get('save_kwargs', {}))
             else:
@@ -558,6 +565,8 @@ class ETL_Base(object):
             output.write.partitionBy(*partitionby).mode(write_mode).parquet(path)
         elif type == 'csv':
             output.write.partitionBy(*partitionby).mode(write_mode).option("header", "true").csv(path)
+        elif type == 'json':
+            output.write.partitionBy(*partitionby).mode(write_mode).json(path)
         else:
             raise Exception("Need to specify supported output type, either txt, parquet or csv.")
 

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -366,6 +366,16 @@ class ETL_Base(object):
             # logger.info("Input data types: {}".format(pformat([(fd.name, fd.dataType) for fd in sdf.schema.fields])))  # TODO adapt to pandas
             return pdf
 
+        if self.jargs.inputs[input_name].get('df_type') == 'json_pandas':
+            globy = self.jargs.inputs[input_name].get('glob')
+            if input_type == 'json':
+                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='json', globy=globy, read_func='json_parser', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))  # TODO: improve jsonlib name
+            else:
+                raise Exception("Unsupported input type '{}' for path '{}'. Supported types for pandas are: {}. ".format(input_type, self.jargs.inputs[input_name].get('path'), self.PANDAS_DF_TYPES))
+            logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
+            # logger.info("Input data types: {}".format(pformat([(fd.name, fd.dataType) for fd in sdf.schema.fields])))  # TODO adapt to pandas
+            return pdf
+
         # Tabular types, Spark
         if input_type == 'csv':
             delimiter = self.jargs.merged_args.get('csv_delimiter', ',')
@@ -393,7 +403,7 @@ class ETL_Base(object):
         """Loading any dataset (input or not) and only from file system (not from DBs). Used by incremental jobs to load previous output.
         Different from load_input() which only loads input (input jargs hardcoded) and from any source."""
         # TODO: integrate with load_input to remove duplicated code.
-        input_type = type
+        input_type = type  # TODO: remove 'input_' prefix in code below since not specific to input. 
         input_name = name
         input = df_meta  # TODO: get 2 variables above from this one.
         path = path.replace('s3://', 's3a://') if self.jargs.mode == 'dev_local' else path

--- a/yaetos/pandas_utils.py
+++ b/yaetos/pandas_utils.py
@@ -3,6 +3,7 @@ Helper functions for pandas as engine.
 """
 import pandas as pd
 import glob
+import json
 import os
 from pathlib import Path
 from yaetos.logger import setup_logging
@@ -59,14 +60,41 @@ def load_csvs(path, read_kwargs):
 #def load_df(path, file_type='csv', read_func='read_csv', read_kwargs={}):
 def load_dfs(path, file_type='csv', globy=None, read_func='read_csv', read_kwargs={}):
     """Loading 1 file or multiple depending on path"""
-    if path.endswith(".{}".format(file_type)):
-        func = getattr(pd, read_func)
-        return func(path, **read_kwargs)
-    elif path.endswith('/'):
-        return load_multiple_files(path, file_type, read_func, read_kwargs)
-    else:
+    print(f"33333 {file_type}, {globy}")
+    if globy:
+        # TODO: improve check, make it usable with several files.
+        matching_paths = glob.glob(globy)
+        matches_pattern = os.path.normpath(path) in map(os.path.normpath, matching_paths)
+
+    # import ipdb; ipdb.set_trace()
+    if path.endswith(".{}".format(file_type)):  # one file and extension is explicite
+        # func = getattr(pd, read_func)
+        # return func(path, **read_kwargs)
+        return load_df(path, read_func, read_kwargs)
+    elif globy and matches_pattern:  # one file and extension is not explicite
+        # func = getattr(pd, read_func)
+        # return func(path, **read_kwargs)
+        return load_df(path, read_func, read_kwargs)
+    elif path.endswith('/'):  # multiple files.
+        # return load_multiple_files(path, file_type, read_func, read_kwargs)
+        return load_multiple_files(path, globy, read_func, read_kwargs)
+    else:  # case where file has no extension. TODO: make above more generic by using glob.
+        # func = getattr(pd, read_func)
+        # return func(path, **read_kwargs)
         raise Exception("Path should end with '.{}' or '/'.".format(file_type))
 
+def load_df(path, read_func='read_csv', read_kwargs={}):
+    """Loading 1 file or multiple depending on path"""
+
+    print(f"### load_df: {path}")
+
+    if read_func != 'json_parser':
+        func = getattr(pd, read_func)
+        return func(path, **read_kwargs)
+    else:
+        with open(path, 'r') as file:
+            data = json.load(file)
+        return pd.DataFrame(data['records'])
 
 # --- saving files ----
 

--- a/yaetos/pandas_utils.py
+++ b/yaetos/pandas_utils.py
@@ -28,7 +28,7 @@ def load_multiple_csvs(path, read_kwargs):
 def load_multiple_files(path, globy='*.csv', read_func='read_csv', read_kwargs={}, add_file_fol=True):
     files = glob.glob(os.path.join(path, globy))  # removes local files
     files = [file for file in files if not os.path.basename(file).startswith('.')]  # remove sys files added by OS, ex .DS_store in mac.
-    
+
     dfs = []
     for fi in files:
         df = load_df(fi, read_func, read_kwargs)
@@ -67,6 +67,7 @@ def load_dfs(path, file_type='csv', globy=None, read_func='read_csv', read_kwarg
     else:  # case where file has no extension. TODO: make above more generic by using glob.
         raise Exception("Path should end with '.{}' or '/'.".format(file_type))
 
+
 def load_df(path, read_func='read_csv', read_kwargs={}):
     """Loading 1 file or multiple depending on path"""
     if read_func != 'json_parser':
@@ -76,6 +77,7 @@ def load_df(path, read_func='read_csv', read_kwargs={}):
         with open(path, 'r') as file:
             data = json.load(file)
         return pd.DataFrame(data['records'])
+
 
 # --- saving files ----
 
@@ -107,7 +109,3 @@ def query_pandas(query_str, dfs):
         con.register(key, value)
     df = con.execute(query_str).df()
     return df
-
-
-if __name__ == '__main__':
-    pass

--- a/yaetos/pandas_utils.py
+++ b/yaetos/pandas_utils.py
@@ -39,7 +39,7 @@ def load_multiple_files(path, file_type='csv', read_func='read_csv', read_kwargs
 
 def load_csvs(path, read_kwargs):
     """Loading 1 csv or multiple depending on path"""
-    # TODO: to be made obsolete once load_df works
+    # TODO: to be made obsolete once load_dfs works
     if path.endswith('.csv'):
         return pd.read_csv(path, **read_kwargs)
     elif path.endswith('/'):
@@ -48,7 +48,8 @@ def load_csvs(path, read_kwargs):
         raise Exception("Path should end with '.csv' or '/'.".format())
 
 
-def load_df(path, file_type='csv', read_func='read_csv', read_kwargs={}):
+#def load_df(path, file_type='csv', read_func='read_csv', read_kwargs={}):
+def load_dfs(path, file_type='csv', globy=None, read_func='read_csv', read_kwargs={}):
     """Loading 1 file or multiple depending on path"""
     if path.endswith(".{}".format(file_type)):
         func = getattr(pd, read_func)

--- a/yaetos/pandas_utils.py
+++ b/yaetos/pandas_utils.py
@@ -26,7 +26,7 @@ def load_multiple_csvs(path, read_kwargs):
 
 
 def load_multiple_files(path, globy='*.csv', read_func='read_csv', read_kwargs={}, add_file_fol=True):
-    files = glob.glob(os.path.join(path, globy))  # removes local files added by 
+    files = glob.glob(os.path.join(path, globy))  # removes local files
     files = [file for file in files if not os.path.basename(file).startswith('.')]  # remove sys files added by OS, ex .DS_store in mac.
     
     dfs = []
@@ -62,6 +62,7 @@ def load_dfs(path, file_type='csv', globy=None, read_func='read_csv', read_kwarg
     elif globy and matches_pattern:  # one file and extension is not explicite
         return load_df(path, read_func, read_kwargs)
     elif path.endswith('/'):  # multiple files.
+        globy = globy or f'*.{file_type}'
         return load_multiple_files(path, globy, read_func, read_kwargs)
     else:  # case where file has no extension. TODO: make above more generic by using glob.
         raise Exception("Path should end with '.{}' or '/'.".format(file_type))

--- a/yaetos/pandas_utils.py
+++ b/yaetos/pandas_utils.py
@@ -24,16 +24,24 @@ def load_multiple_csvs(path, read_kwargs):
     return df.reset_index(drop=True)
 
 
-def load_multiple_files(path, file_type='csv', read_func='read_csv', read_kwargs={}, add_file_fol=True):
-    files = glob.glob(os.path.join(path, "*.{}".format(file_type)))
-    func = getattr(pd, read_func)
+#def load_multiple_files(path, file_type='csv', read_func='read_csv', read_kwargs={}, add_file_fol=True):
+def load_multiple_files(path, globy='*.csv', read_func='read_csv', read_kwargs={}, add_file_fol=True):
+    # files = glob.glob(os.path.join(path, "*.{}".format(file_type)))
+    files = glob.glob(os.path.join(path, globy))  # removes local files added by OS, like .DS_store in mac.
+    files = [file for file in files if not os.path.basename(file).startswith('.')]
+    
+    # import ipdb; ipdb.set_trace()
+    # func = getattr(pd, read_func)
     dfs = []
     for fi in files:
-        df = func(fi, **read_kwargs)
+        # import ipdb; ipdb.set_trace()
+        # df = func(fi, **read_kwargs)
+        df = load_df(fi, read_func, read_kwargs)
         if add_file_fol:
             df['_source'] = fi
         dfs.append(df)
-    df = pd.concat(dfs)
+    df = pd.concat(dfs) if len(dfs) >= 1 else pd.DataFrame()
+    # import ipdb; ipdb.set_trace()
     return df.reset_index(drop=True)
 
 

--- a/yaetos/pandas_utils.py
+++ b/yaetos/pandas_utils.py
@@ -25,24 +25,17 @@ def load_multiple_csvs(path, read_kwargs):
     return df.reset_index(drop=True)
 
 
-#def load_multiple_files(path, file_type='csv', read_func='read_csv', read_kwargs={}, add_file_fol=True):
 def load_multiple_files(path, globy='*.csv', read_func='read_csv', read_kwargs={}, add_file_fol=True):
-    # files = glob.glob(os.path.join(path, "*.{}".format(file_type)))
-    files = glob.glob(os.path.join(path, globy))  # removes local files added by OS, like .DS_store in mac.
-    files = [file for file in files if not os.path.basename(file).startswith('.')]
+    files = glob.glob(os.path.join(path, globy))  # removes local files added by 
+    files = [file for file in files if not os.path.basename(file).startswith('.')]  # remove sys files added by OS, ex .DS_store in mac.
     
-    # import ipdb; ipdb.set_trace()
-    # func = getattr(pd, read_func)
     dfs = []
     for fi in files:
-        # import ipdb; ipdb.set_trace()
-        # df = func(fi, **read_kwargs)
         df = load_df(fi, read_func, read_kwargs)
         if add_file_fol:
             df['_source'] = fi
         dfs.append(df)
     df = pd.concat(dfs) if len(dfs) >= 1 else pd.DataFrame()
-    # import ipdb; ipdb.set_trace()
     return df.reset_index(drop=True)
 
 
@@ -57,37 +50,24 @@ def load_csvs(path, read_kwargs):
         raise Exception("Path should end with '.csv' or '/'.".format())
 
 
-#def load_df(path, file_type='csv', read_func='read_csv', read_kwargs={}):
 def load_dfs(path, file_type='csv', globy=None, read_func='read_csv', read_kwargs={}):
     """Loading 1 file or multiple depending on path"""
-    print(f"33333 {file_type}, {globy}")
     if globy:
         # TODO: improve check, make it usable with several files.
         matching_paths = glob.glob(globy)
         matches_pattern = os.path.normpath(path) in map(os.path.normpath, matching_paths)
 
-    # import ipdb; ipdb.set_trace()
     if path.endswith(".{}".format(file_type)):  # one file and extension is explicite
-        # func = getattr(pd, read_func)
-        # return func(path, **read_kwargs)
         return load_df(path, read_func, read_kwargs)
     elif globy and matches_pattern:  # one file and extension is not explicite
-        # func = getattr(pd, read_func)
-        # return func(path, **read_kwargs)
         return load_df(path, read_func, read_kwargs)
     elif path.endswith('/'):  # multiple files.
-        # return load_multiple_files(path, file_type, read_func, read_kwargs)
         return load_multiple_files(path, globy, read_func, read_kwargs)
     else:  # case where file has no extension. TODO: make above more generic by using glob.
-        # func = getattr(pd, read_func)
-        # return func(path, **read_kwargs)
         raise Exception("Path should end with '.{}' or '/'.".format(file_type))
 
 def load_df(path, read_func='read_csv', read_kwargs={}):
     """Loading 1 file or multiple depending on path"""
-
-    print(f"### load_df: {path}")
-
     if read_func != 'json_parser':
         func = getattr(pd, read_func)
         return func(path, **read_kwargs)


### PR DESCRIPTION
Added support for loading json files:
 * support 3 json formats, see tests/fixtures/data_sample/wiki_example/input_json_format{1,2,3}/dataset.json and corresponding demo jobs in jobs_metadata.yml
 * one of them (with data rows contained in "records" field ) implies loading with json lib and then loading with pandas (i.e. not using `pd.read_json()`), so had to create a new df_type: "json_pandas", to be used in jobs_metadata.yml

Added a job showing loading and processing multiple paths with same dataset schema:
 * deals with data organised as `some_path/{category}/{subcategory}/some_dataset"`
 * it will load and process all combinations of `category` and `subcategory` in path, as specified in jobs_metadata.yml
 * benefit: no need to provided all inputs as hardcoded list & can outputs 1 dataset for each input
 * implies having job overwrite new functions `expand_input_path` and `expand_output_path` to capture variables to replace.

Added ability to provide glob, 
 * benefit: avoiding loading all files from a path in S3 to then filter a subset. 