### PR TITLE
Copy raw job

### DIFF
--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -286,6 +286,7 @@ jobs:
     load_connectors: all
 
   examples/ex14_json_format1_load_job:
+    description: "Format with basic json, with rows as lines, without []."
     py_job: jobs/generic/copy_job.py
     inputs:
       table_to_copy: {'path':"tests/fixtures/data_sample/wiki_example/input_json_format1/dataset.json", 'type':'json', 'df_type':'pandas', 'read_kwargs':{'lines':True}}
@@ -293,6 +294,7 @@ jobs:
     spark_boot: False
 
   examples/ex14_json_format2_load_job:
+    description: "Format with basic valid json, with rows inside brackets, ex [rows_here]."
     py_job: jobs/generic/copy_job.py
     inputs:
       table_to_copy: {'path':"tests/fixtures/data_sample/wiki_example/input_json_format2/dataset.json", 'type':'json', 'df_type':'pandas'}
@@ -300,6 +302,7 @@ jobs:
     spark_boot: False
 
   examples/ex14_json_format3_load_job:
+    description: "Format with rows inside structure like {'records':[rows_here]}."
     py_job: jobs/generic/copy_job.py
     inputs:
       table_to_copy: {'path':"tests/fixtures/data_sample/wiki_example/input_json_format3/dataset.json", 'type':'json', 'df_type':'json_pandas'}

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -239,7 +239,7 @@ jobs:
     description: "Copy data from cloud to local. Not loading file content. To be run locally."
     py_job: jobs/generic/copy_raw_job.py
     inputs:
-      table_to_copy: {'path':"{base_path}/load_example/test_files/", 'glob':'*/*.csv', 'type':'other'}
+      files_to_copy: {'path':"{base_path}/load_example/test_files/", 'glob':'*/*.csv', 'type':'other'}
     output: {'path':'./data/load_example/test_files/{now}/'}
     base_path: 's3://mylake-dev/pipelines_data'
     aws_config_file:  conf/aws_config.cfg

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -235,6 +235,17 @@ jobs:
     aws_setup: dev
     load_connectors: all
 
+  examples/copy_cloud_to_local_job:
+    description: "Copy data from cloud to local. Not loading file content. To be run locally."
+    py_job: jobs/generic/copy_raw_job.py
+    inputs:
+      table_to_copy: {'path':"{base_path}/load_example/test_files/", 'glob':'*/*.csv', 'type':'other'}
+    output: {'path':'./data/load_example/test_files/{now}/'}
+    base_path: 's3://mylake-dev/pipelines_data'
+    aws_config_file:  conf/aws_config.cfg
+    aws_setup: dev
+    spark_boot: False
+
   examples/ex11_run_gpu_for_deeplearning.py:
     description: ""
     inputs:

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -12,8 +12,8 @@ class Job(ETL_Base):
 
         # Paths
         path_raw_in = self.jargs.inputs['table_to_copy']['path']
-        path_raw_in2 = self.expand_input_path(path_raw_in)
-        path_raw_in3 = CPt(path_raw_in2)
+        path_raw_in = self.expand_input_path(path_raw_in)
+        path_raw_in = CPt(path_raw_in)
         path_raw_out = self.jargs.output['path']
         path_raw_out2 = self.expand_output_path(path_raw_out, now_dt=self.start_dt)
         if 'glob' in self.jargs.inputs['table_to_copy'].keys():
@@ -30,8 +30,8 @@ class Job(ETL_Base):
         session = boto3.session.Session()
         s3 = session.client('s3')
 
-        bucket_name = path_raw_in3.bucket  # Replace with your bucket name
-        prefix = path_raw_in3.key  # Replace with the folder path in your bucket
+        bucket_name = path_raw_in.bucket  # Replace with your bucket name
+        prefix = path_raw_in.key  # Replace with the folder path in your bucket
         local_directory = path_raw_out2  # Replace with your local directory path
 
         file_number = self.get_size(s3, bucket_name, prefix, pattern, pattern_type)

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -43,19 +43,18 @@ class Job(ETL_Base):
                 for obj in page['Contents']:
                     file_name = obj['Key'][len(path_raw_in.key):]
                     match = self.get_match(file_name, pattern, pattern_type)
+                    if not match:
+                        continue
 
-                    if match:
-                        # Extract the file name from the object key and create its local path
-                        local_file_path = os.path.join(path_raw_out, file_name)
+                    # Create subdirectories if they don't exist
+                    local_file_path = os.path.join(path_raw_out, file_name)
+                    local_file_directory = os.path.dirname(local_file_path)
+                    if not os.path.exists(local_file_directory):
+                        os.makedirs(local_file_directory)
 
-                        # Create subdirectories if they don't exist
-                        local_file_directory = os.path.dirname(local_file_path)
-                        if not os.path.exists(local_file_directory):
-                            os.makedirs(local_file_directory)
-
-                        # Download the file
-                        s3.download_file(path_raw_in.bucket, obj['Key'], local_file_path)
-                        print(f"Downloaded {obj['Key']} to {local_file_path}")
+                    # Download the file
+                    s3.download_file(path_raw_in.bucket, obj['Key'], local_file_path)
+                    print(f"Downloaded {obj['Key']} to {local_file_path}")
 
         return None
 
@@ -80,7 +79,6 @@ class Job(ETL_Base):
                 for obj in page['Contents']:
                     file_name = obj['Key'][len(prefix):]
                     match = self.get_match(file_name, pattern, pattern_type)
-
                     if match:
                         matching_files_count += 1
         return matching_files_count

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -1,5 +1,4 @@
 from yaetos.etl_utils import ETL_Base, Commandliner, get_aws_setup
-import boto3
 import os
 from cloudpathlib import CloudPath as CPt
 import fnmatch

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -1,4 +1,4 @@
-from yaetos.etl_utils import ETL_Base, Commandliner
+from yaetos.etl_utils import ETL_Base, Commandliner, get_aws_setup
 import boto3
 import os
 from cloudpathlib import CloudPath as CPt
@@ -27,7 +27,8 @@ class Job(ETL_Base):
             pattern_type = 'glob'
 
         # Initialize a boto3 session
-        session = boto3.session.Session()
+        # session = boto3.session.Session(profile_name=self.profile_name)
+        session = get_aws_setup(self.jargs.merged_args)
         s3 = session.client('s3')
 
         bucket_name = path_raw_in.bucket  # Replace with your bucket name

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -34,30 +34,6 @@ class Job(ETL_Base):
 
         self.download_files(s3, path_raw_in.bucket, path_raw_in.key, pattern, pattern_type, path_raw_out)
         self.logger.info("Finished downloading all files")
-        # # Create the local directory if it doesn't exist
-        # if not os.path.exists(path_raw_out):
-        #     os.makedirs(path_raw_out)
-
-        # List objects within the specified folder
-        # paginator = s3.get_paginator('list_objects_v2')
-        # for page in paginator.paginate(Bucket=path_raw_in.bucket, Prefix=path_raw_in.key):
-        #     if 'Contents' in page:
-        #         for obj in page['Contents']:
-        #             file_name = obj['Key'][len(path_raw_in.key):]
-        #             match = self.get_match(file_name, pattern, pattern_type)
-        #             if not match:
-        #                 continue
-
-                    # # Create subdirectories if they don't exist
-                    # local_file_path = os.path.join(path_raw_out, file_name)
-                    # local_file_directory = os.path.dirname(local_file_path)
-                    # if not os.path.exists(local_file_directory):
-                    #     os.makedirs(local_file_directory)
-
-                    # # Download the file
-                    # s3.download_file(path_raw_in.bucket, obj['Key'], local_file_path)
-                    # print(f"Downloaded {obj['Key']} to {local_file_path}")
-
         return None
 
     @staticmethod
@@ -70,7 +46,6 @@ class Job(ETL_Base):
             match = True
         return match
 
-
     def s3_iterator(self, s3, bucket_name, prefix, pattern, pattern_type):
         paginator = s3.get_paginator('list_objects_v2')
         for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
@@ -80,20 +55,6 @@ class Job(ETL_Base):
                     match = self.get_match(file_name, pattern, pattern_type)
                     if match:
                         yield obj, file_name
-
-        # for item in data:
-        #     # Complex loop operations
-        #     yield item
-
-    # @staticmethod
-    # def apply_over_files(self, func, s3, bucket_name, prefix, pattern, pattern_type):
-    #     paginator = s3.get_paginator('list_objects_v2')
-    #     for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
-    #         if 'Contents' in page:
-    #             for obj in page['Contents']:
-    #                 file_name = obj['Key'][len(prefix):]
-    #                 match = self.get_match(file_name, pattern, pattern_type)
-    #                 func(match)
 
     def download_files(self, s3, bucket_name, prefix, pattern, pattern_type, path_raw_out):
         # Create the local directory if it doesn't exist
@@ -117,15 +78,6 @@ class Job(ETL_Base):
         for (obj, file_name) in self.s3_iterator(s3, bucket_name, prefix, pattern, pattern_type):
             matching_files_count += 1
 
-        # # List objects within the specified folder
-        # paginator = s3.get_paginator('list_objects_v2')
-        # for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
-        #     if 'Contents' in page:
-        #         for obj in page['Contents']:
-        #             file_name = obj['Key'][len(prefix):]
-        #             match = self.get_match(file_name, pattern, pattern_type)
-        #             if match:
-        #                 matching_files_count += 1
         return matching_files_count
 
 

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -6,15 +6,14 @@ import re
 
 
 class Job(ETL_Base):
-
     def transform(self, files_to_copy):
-
-        # Paths
         path_raw_in = self.jargs.inputs['files_to_copy']['path']
         path_raw_in = self.expand_input_path(path_raw_in)
         path_raw_in = CPt(path_raw_in)
         path_raw_out = self.jargs.output['path']
         path_raw_out = self.expand_output_path(path_raw_out, now_dt=self.start_dt)
+
+        # Get pattern and pattern_type
         if 'glob' in self.jargs.inputs['files_to_copy'].keys():
             pattern = self.jargs.inputs['files_to_copy']['glob']
             pattern_type = 'glob'
@@ -56,7 +55,6 @@ class Job(ETL_Base):
         matching_files_count = 0
         for (obj, file_name) in self.s3_iterator(s3, bucket_name, prefix, pattern, pattern_type):
             matching_files_count += 1
-
         return matching_files_count
 
     def s3_iterator(self, s3, bucket_name, prefix, pattern, pattern_type):

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -16,8 +16,6 @@ class Job(ETL_Base):
         path_raw_in3 = CPt(path_raw_in2)
         path_raw_out = self.jargs.output['path']
         path_raw_out2 = self.expand_output_path(path_raw_out, now_dt=self.start_dt)
-        # globy = self.jargs.inputs['table_to_copy'].get('glob', '*')
-        # regy = self.jargs.inputs['table_to_copy'].get('regex', '*')
         if 'glob' in self.jargs.inputs['table_to_copy'].keys():
             pattern = self.jargs.inputs['table_to_copy']['glob']
             pattern_type = 'glob'
@@ -35,9 +33,7 @@ class Job(ETL_Base):
         bucket_name = path_raw_in3.bucket  # Replace with your bucket name
         prefix = path_raw_in3.key  # Replace with the folder path in your bucket
         local_directory = path_raw_out2  # Replace with your local directory path
-        # pattern =   # Replace with your glob pattern, e.g., '*.txt' for all text files
 
-        # import ipdb; ipdb.set_trace()
         file_number = self.get_size(s3, bucket_name, prefix, pattern, pattern_type)
         self.logger.info(f"Number of files to be downloaded {file_number}")
 
@@ -90,7 +86,6 @@ class Job(ETL_Base):
                         match = True
 
                     if match:
-                        # Increment the counter for each matching file
                         matching_files_count += 1
         return matching_files_count
 

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -32,29 +32,31 @@ class Job(ETL_Base):
         file_number = self.get_size(s3, path_raw_in.bucket, path_raw_in.key, pattern, pattern_type)
         self.logger.info(f"Number of files to be downloaded {file_number}")
 
-        # Create the local directory if it doesn't exist
-        if not os.path.exists(path_raw_out):
-            os.makedirs(path_raw_out)
+        self.download_files(s3, path_raw_in.bucket, path_raw_in.key, pattern, pattern_type, path_raw_out)
+        self.logger.info("Finished downloading all files")
+        # # Create the local directory if it doesn't exist
+        # if not os.path.exists(path_raw_out):
+        #     os.makedirs(path_raw_out)
 
         # List objects within the specified folder
-        paginator = s3.get_paginator('list_objects_v2')
-        for page in paginator.paginate(Bucket=path_raw_in.bucket, Prefix=path_raw_in.key):
-            if 'Contents' in page:
-                for obj in page['Contents']:
-                    file_name = obj['Key'][len(path_raw_in.key):]
-                    match = self.get_match(file_name, pattern, pattern_type)
-                    if not match:
-                        continue
+        # paginator = s3.get_paginator('list_objects_v2')
+        # for page in paginator.paginate(Bucket=path_raw_in.bucket, Prefix=path_raw_in.key):
+        #     if 'Contents' in page:
+        #         for obj in page['Contents']:
+        #             file_name = obj['Key'][len(path_raw_in.key):]
+        #             match = self.get_match(file_name, pattern, pattern_type)
+        #             if not match:
+        #                 continue
 
-                    # Create subdirectories if they don't exist
-                    local_file_path = os.path.join(path_raw_out, file_name)
-                    local_file_directory = os.path.dirname(local_file_path)
-                    if not os.path.exists(local_file_directory):
-                        os.makedirs(local_file_directory)
+                    # # Create subdirectories if they don't exist
+                    # local_file_path = os.path.join(path_raw_out, file_name)
+                    # local_file_directory = os.path.dirname(local_file_path)
+                    # if not os.path.exists(local_file_directory):
+                    #     os.makedirs(local_file_directory)
 
-                    # Download the file
-                    s3.download_file(path_raw_in.bucket, obj['Key'], local_file_path)
-                    print(f"Downloaded {obj['Key']} to {local_file_path}")
+                    # # Download the file
+                    # s3.download_file(path_raw_in.bucket, obj['Key'], local_file_path)
+                    # print(f"Downloaded {obj['Key']} to {local_file_path}")
 
         return None
 
@@ -69,10 +71,7 @@ class Job(ETL_Base):
         return match
 
 
-    def get_size(self, s3, bucket_name, prefix, pattern, pattern_type):
-        matching_files_count = 0
-
-        # List objects within the specified folder
+    def s3_iterator(self, s3, bucket_name, prefix, pattern, pattern_type):
         paginator = s3.get_paginator('list_objects_v2')
         for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
             if 'Contents' in page:
@@ -80,7 +79,53 @@ class Job(ETL_Base):
                     file_name = obj['Key'][len(prefix):]
                     match = self.get_match(file_name, pattern, pattern_type)
                     if match:
-                        matching_files_count += 1
+                        yield obj, file_name
+
+        # for item in data:
+        #     # Complex loop operations
+        #     yield item
+
+    # @staticmethod
+    # def apply_over_files(self, func, s3, bucket_name, prefix, pattern, pattern_type):
+    #     paginator = s3.get_paginator('list_objects_v2')
+    #     for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
+    #         if 'Contents' in page:
+    #             for obj in page['Contents']:
+    #                 file_name = obj['Key'][len(prefix):]
+    #                 match = self.get_match(file_name, pattern, pattern_type)
+    #                 func(match)
+
+    def download_files(self, s3, bucket_name, prefix, pattern, pattern_type, path_raw_out):
+        # Create the local directory if it doesn't exist
+        if not os.path.exists(path_raw_out):
+            os.makedirs(path_raw_out)
+
+        for (obj, file_name) in self.s3_iterator(s3, bucket_name, prefix, pattern, pattern_type):
+            local_file_path = os.path.join(path_raw_out, file_name)
+
+            # Create subdirectories if they don't exist
+            local_file_directory = os.path.dirname(local_file_path)
+            if not os.path.exists(local_file_directory):
+                os.makedirs(local_file_directory)
+
+            # Download the file
+            s3.download_file(bucket_name, obj['Key'], local_file_path)
+            print(f"Downloaded {obj['Key']} to {local_file_path}")
+
+    def get_size(self, s3, bucket_name, prefix, pattern, pattern_type):
+        matching_files_count = 0
+        for (obj, file_name) in self.s3_iterator(s3, bucket_name, prefix, pattern, pattern_type):
+            matching_files_count += 1
+
+        # # List objects within the specified folder
+        # paginator = s3.get_paginator('list_objects_v2')
+        # for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
+        #     if 'Contents' in page:
+        #         for obj in page['Contents']:
+        #             file_name = obj['Key'][len(prefix):]
+        #             match = self.get_match(file_name, pattern, pattern_type)
+        #             if match:
+        #                 matching_files_count += 1
         return matching_files_count
 
 

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -15,7 +15,7 @@ class Job(ETL_Base):
         path_raw_in = self.expand_input_path(path_raw_in)
         path_raw_in = CPt(path_raw_in)
         path_raw_out = self.jargs.output['path']
-        path_raw_out2 = self.expand_output_path(path_raw_out, now_dt=self.start_dt)
+        path_raw_out = self.expand_output_path(path_raw_out, now_dt=self.start_dt)
         if 'glob' in self.jargs.inputs['files_to_copy'].keys():
             pattern = self.jargs.inputs['files_to_copy']['glob']
             pattern_type = 'glob'
@@ -33,7 +33,7 @@ class Job(ETL_Base):
 
         bucket_name = path_raw_in.bucket  # Replace with your bucket name
         prefix = path_raw_in.key  # Replace with the folder path in your bucket
-        local_directory = path_raw_out2  # Replace with your local directory path
+        local_directory = path_raw_out  # Replace with your local directory path
 
         file_number = self.get_size(s3, bucket_name, prefix, pattern, pattern_type)
         self.logger.info(f"Number of files to be downloaded {file_number}")

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -1,0 +1,100 @@
+from yaetos.etl_utils import ETL_Base, Commandliner
+import boto3
+import os
+from pathlib import Path as Pt
+from cloudpathlib import CloudPath as CPt
+import fnmatch
+import re
+
+class Job(ETL_Base):
+
+    def transform(self, table_to_copy):
+
+        # Paths
+        path_raw_in = self.jargs.inputs['table_to_copy']['path']
+        path_raw_in2 = self.expand_input_path(path_raw_in)
+        path_raw_in3 = CPt(path_raw_in2)
+        path_raw_out = self.jargs.output['path']
+        path_raw_out2 = self.expand_output_path(path_raw_out, now_dt=self.start_dt)
+        # globy = self.jargs.inputs['table_to_copy'].get('glob', '*')
+        # regy = self.jargs.inputs['table_to_copy'].get('regex', '*')
+        if 'glob' in self.jargs.inputs['table_to_copy'].keys():
+            pattern = self.jargs.inputs['table_to_copy']['glob']
+            pattern_type = 'glob'
+        elif 'regex' in self.jargs.inputs['table_to_copy'].keys():
+            pattern = self.jargs.inputs['table_to_copy']['regex']
+            pattern_type = 'regex'
+        else:
+            pattern = '*'
+            pattern_type = 'glob'
+
+        # Initialize a boto3 session
+        session = boto3.session.Session()
+        s3 = session.client('s3')
+
+        bucket_name = path_raw_in3.bucket  # Replace with your bucket name
+        prefix = path_raw_in3.key  # Replace with the folder path in your bucket
+        local_directory = path_raw_out2  # Replace with your local directory path
+        # pattern =   # Replace with your glob pattern, e.g., '*.txt' for all text files
+
+        # import ipdb; ipdb.set_trace()
+        file_number = self.get_size(s3, bucket_name, prefix, pattern, pattern_type)
+        self.logger.info(f"Number of files to be downloaded {file_number}")
+
+        # Create the local directory if it doesn't exist
+        if not os.path.exists(local_directory):
+            os.makedirs(local_directory)
+
+        # List objects within the specified folder
+        paginator = s3.get_paginator('list_objects_v2')
+        for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
+            if 'Contents' in page:
+                for obj in page['Contents']:
+                    file_name = obj['Key'][len(prefix):]
+                    if pattern_type == 'glob':
+                        match = fnmatch.fnmatch(file_name, pattern)
+                    elif pattern_type == 'regex':
+                        match = re.match(pattern, file_name)
+                    else:
+                        match = True
+
+                    if match:
+                        # Extract the file name from the object key and create its local path
+                        local_file_path = os.path.join(local_directory, file_name)
+
+                        # Create subdirectories if they don't exist
+                        local_file_directory = os.path.dirname(local_file_path)
+                        if not os.path.exists(local_file_directory):
+                            os.makedirs(local_file_directory)
+
+                        # Download the file
+                        s3.download_file(bucket_name, obj['Key'], local_file_path)
+                        print(f"Downloaded {obj['Key']} to {local_file_path}")
+
+        return None
+
+    def get_size(self, s3, bucket_name, prefix, pattern, pattern_type):
+        matching_files_count = 0
+
+        # List objects within the specified folder
+        paginator = s3.get_paginator('list_objects_v2')
+        for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
+            if 'Contents' in page:
+                for obj in page['Contents']:
+                    file_name = obj['Key'][len(prefix):]
+                    if pattern_type == 'glob':
+                        match = fnmatch.fnmatch(file_name, pattern)
+                    elif pattern_type == 'regex':
+                        match = re.match(pattern, file_name)
+                    else:
+                        match = True
+
+                    if match:
+                        # Increment the counter for each matching file
+                        matching_files_count += 1
+        return matching_files_count
+
+
+if __name__ == "__main__":
+    args = {'job_param_file': 'conf/jobs_metadata.yml'}
+    Commandliner(Job, **args)

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -1,10 +1,10 @@
 from yaetos.etl_utils import ETL_Base, Commandliner
 import boto3
 import os
-from pathlib import Path as Pt
 from cloudpathlib import CloudPath as CPt
 import fnmatch
 import re
+
 
 class Job(ETL_Base):
 

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -8,19 +8,19 @@ import re
 
 class Job(ETL_Base):
 
-    def transform(self, table_to_copy):
+    def transform(self, files_to_copy):
 
         # Paths
-        path_raw_in = self.jargs.inputs['table_to_copy']['path']
+        path_raw_in = self.jargs.inputs['files_to_copy']['path']
         path_raw_in = self.expand_input_path(path_raw_in)
         path_raw_in = CPt(path_raw_in)
         path_raw_out = self.jargs.output['path']
         path_raw_out2 = self.expand_output_path(path_raw_out, now_dt=self.start_dt)
-        if 'glob' in self.jargs.inputs['table_to_copy'].keys():
-            pattern = self.jargs.inputs['table_to_copy']['glob']
+        if 'glob' in self.jargs.inputs['files_to_copy'].keys():
+            pattern = self.jargs.inputs['files_to_copy']['glob']
             pattern_type = 'glob'
-        elif 'regex' in self.jargs.inputs['table_to_copy'].keys():
-            pattern = self.jargs.inputs['table_to_copy']['regex']
+        elif 'regex' in self.jargs.inputs['files_to_copy'].keys():
+            pattern = self.jargs.inputs['files_to_copy']['regex']
             pattern_type = 'regex'
         else:
             pattern = '*'

--- a/jobs/generic/launcher.py
+++ b/jobs/generic/launcher.py
@@ -8,6 +8,5 @@ from yaetos.etl_utils import Commandliner
 args = {
     'job_param_file': 'conf/jobs_metadata.yml',
     'launcher_file': 'jobs/generic/launcher.py',
-    }
+}
 Commandliner(Job=None, **args)
-

--- a/jobs/generic/launcher.py
+++ b/jobs/generic/launcher.py
@@ -2,7 +2,12 @@
 File needed to run jobs from the yaml manifest (jobs_metadata.yml)
 Usage: $ python jobs/generic/launcher.py --job_name=some_job_name_from_manifest
 """
-
 from yaetos.etl_utils import Commandliner
 
-Commandliner(Job=None, launcher_file='jobs/generic/launcher.py')
+
+args = {
+    'job_param_file': 'conf/jobs_metadata.yml',
+    'launcher_file': 'jobs/generic/launcher.py',
+    }
+Commandliner(Job=None, **args)
+

--- a/jobs/generic/sql_pandas_job.py
+++ b/jobs/generic/sql_pandas_job.py
@@ -3,4 +3,5 @@ from yaetos.sql_pandas_job import Job
 
 
 if __name__ == "__main__":
-    Commandliner(Job)
+    args = {'job_param_file': 'conf/jobs_metadata.yml'}
+    Commandliner(Job, **args)

--- a/jobs/generic/sql_spark_job.py
+++ b/jobs/generic/sql_spark_job.py
@@ -3,4 +3,5 @@ from yaetos.sql_spark_job import Job
 
 
 if __name__ == "__main__":
-    Commandliner(Job)
+    args = {'job_param_file': 'conf/jobs_metadata.yml'}
+    Commandliner(Job, **args)

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -378,6 +378,16 @@ class ETL_Base(object):
             # logger.info("Input data types: {}".format(pformat([(fd.name, fd.dataType) for fd in sdf.schema.fields])))  # TODO adapt to pandas
             return pdf
 
+        # if self.jargs.inputs[input_name].get('df_type') == 'json':
+        #     globy = self.jargs.inputs[input_name].get('glob')
+        #     if input_type == 'json':
+        #         json_data = FS_Ops_Dispatcher().load_pandas(path, file_type='json', globy=globy, read_func='json_parser', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
+        #     else:
+        #         raise Exception("Unsupported input type '{}' for path '{}'. Supported types for pandas are: {}. ".format(input_type, self.jargs.inputs[input_name].get('path'), self.PANDAS_DF_TYPES))
+        #     logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
+        #     # logger.info("Input data types: {}".format(pformat([(fd.name, fd.dataType) for fd in sdf.schema.fields])))  # TODO adapt to pandas
+        #     return json_data
+
         # Tabular types, Spark
         if input_type == 'csv':
             delimiter = self.jargs.merged_args.get('csv_delimiter', ',')

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -431,7 +431,7 @@ class ETL_Base(object):
         # Tabular, Pandas
         # TODO: move block to pandas_util.py
         if input.get('df_type') == 'pandas':
-            globy = input.get('globy')
+            globy = input.get('glob')
             if input_type == 'csv':
                 pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='csv', globy=globy, read_func='read_csv', read_kwargs=input.get('read_kwargs', {}))
             elif input_type == 'parquet':

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -378,16 +378,6 @@ class ETL_Base(object):
             # logger.info("Input data types: {}".format(pformat([(fd.name, fd.dataType) for fd in sdf.schema.fields])))  # TODO adapt to pandas
             return pdf
 
-        # if self.jargs.inputs[input_name].get('df_type') == 'json':
-        #     globy = self.jargs.inputs[input_name].get('glob')
-        #     if input_type == 'json':
-        #         json_data = FS_Ops_Dispatcher().load_pandas(path, file_type='json', globy=globy, read_func='json_parser', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
-        #     else:
-        #         raise Exception("Unsupported input type '{}' for path '{}'. Supported types for pandas are: {}. ".format(input_type, self.jargs.inputs[input_name].get('path'), self.PANDAS_DF_TYPES))
-        #     logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
-        #     # logger.info("Input data types: {}".format(pformat([(fd.name, fd.dataType) for fd in sdf.schema.fields])))  # TODO adapt to pandas
-        #     return json_data
-
         # Tabular types, Spark
         if input_type == 'csv':
             delimiter = self.jargs.merged_args.get('csv_delimiter', ',')

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -371,7 +371,7 @@ class ETL_Base(object):
         if self.jargs.inputs[input_name].get('df_type') == 'json_pandas':
             globy = self.jargs.inputs[input_name].get('glob')
             if input_type == 'json':
-                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='json', globy=globy, read_func='json_parser', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))  # TODO: improve jsonlib name
+                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='json', globy=globy, read_func='json_parser', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
             else:
                 raise Exception("Unsupported input type '{}' for path '{}'. Supported types for pandas are: {}. ".format(input_type, self.jargs.inputs[input_name].get('path'), self.PANDAS_DF_TYPES))
             logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -51,10 +51,10 @@ JARS = 'https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.13/redshi
 
 
 class ETL_Base(object):
-    TABULAR_TYPES = ('csv', 'parquet', 'json', 'xlsx', 'xls', 'df', 'mysql', 'clickhouse')
+    TABULAR_TYPES = ('csv', 'parquet', 'json', 'xlsx', 'xls', 'pickle', 'df', 'mysql', 'clickhouse')
     SPARK_DF_TYPES = ('csv', 'parquet', 'json', 'xlsx', 'xls', 'df', 'mysql', 'clickhouse')
-    PANDAS_DF_TYPES = ('csv', 'parquet', 'json', 'xlsx', 'xls', 'df')
-    FILE_TYPES = ('csv', 'parquet', 'json', 'xlsx', 'xls', 'txt')
+    PANDAS_DF_TYPES = ('csv', 'parquet', 'json', 'xlsx', 'xls', 'pickle', 'df')
+    FILE_TYPES = ('csv', 'parquet', 'json', 'xlsx', 'xls', 'txt', 'pickle')
     OTHER_TYPES = ('other', 'None')
     SUPPORTED_TYPES = set(TABULAR_TYPES) \
         .union(set(SPARK_DF_TYPES)) \
@@ -360,6 +360,8 @@ class ETL_Base(object):
                 pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='xlsx', globy=globy, read_func='read_excel', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
             elif input_type == 'xls':
                 pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='xls', globy=globy, read_func='read_excel', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
+            elif input_type == 'pickle':
+                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='pickle', globy=globy, read_func='read_pickle', read_kwargs=self.jargs.inputs[input_name].get('read_kwargs', {}))
             else:
                 raise Exception("Unsupported input type '{}' for path '{}'. Supported types for pandas are: {}. ".format(input_type, self.jargs.inputs[input_name].get('path'), self.PANDAS_DF_TYPES))
             logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
@@ -430,6 +432,8 @@ class ETL_Base(object):
                 pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='xlsx', globy=globy, read_func='read_excel', read_kwargs=input.get('read_kwargs', {}))
             elif input_type == 'xls':
                 pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='xls', globy=globy, read_func='read_excel', read_kwargs=input.get('read_kwargs', {}))
+            elif input_type == 'pickle':
+                pdf = FS_Ops_Dispatcher().load_pandas(path, file_type='pickle', globy=globy, read_func='read_pickle', read_kwargs=input.get('read_kwargs', {}))
             else:
                 raise Exception("Unsupported input type '{}' for path '{}'. Supported types for pandas are: {}. ".format(input_type, input.get('path'), self.PANDAS_DF_TYPES))
             logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
@@ -596,6 +600,8 @@ class ETL_Base(object):
                 FS_Ops_Dispatcher().save_pandas(output, path, save_method='to_json', save_kwargs=self.jargs.output.get('save_kwargs', {}))
             elif type in ('xlsx', 'xls'):
                 FS_Ops_Dispatcher().save_pandas(output, path, save_method='to_excel', save_kwargs=self.jargs.output.get('save_kwargs', {}))
+            elif type == 'pickle':
+                FS_Ops_Dispatcher().save_pandas(output, path, save_method='to_pickle', save_kwargs=self.jargs.output.get('save_kwargs', {}))
             else:
                 raise Exception("Need to specify supported output type for pandas, csv, parquet, xls or xlsx.")
             logger.info('Wrote output to ' + path)

--- a/yaetos/pandas_utils.py
+++ b/yaetos/pandas_utils.py
@@ -56,10 +56,13 @@ def load_dfs(path, file_type='csv', globy=None, read_func='read_csv', read_kwarg
         # TODO: improve check, make it usable with several files.
         matching_paths = glob.glob(globy)
         matches_pattern = os.path.normpath(path) in map(os.path.normpath, matching_paths)
+        # import ipdb; ipdb.set_trace()
+        # is_file = Path(matching_paths).is_file()
+        is_file = len(matching_paths) == 1
 
     if path.endswith(".{}".format(file_type)):  # one file and extension is explicite
         return load_df(path, read_func, read_kwargs)
-    elif globy and matches_pattern:  # one file and extension is not explicite
+    elif globy and matches_pattern and is_file:  # one file and extension is not explicite
         return load_df(path, read_func, read_kwargs)
     elif path.endswith('/'):  # multiple files.
         globy = globy or f'*.{file_type}'
@@ -76,7 +79,10 @@ def load_df(path, read_func='read_csv', read_kwargs={}):
     else:
         with open(path, 'r') as file:
             data = json.load(file)
-        return pd.DataFrame(data['records'])
+        # import ipdb; ipdb.set_trace()
+        df = pd.DataFrame(data['records'])
+        # df['data'] = df['data'].fillna({})
+        return df
 
 
 # --- saving files ----

--- a/yaetos/pandas_utils.py
+++ b/yaetos/pandas_utils.py
@@ -56,8 +56,6 @@ def load_dfs(path, file_type='csv', globy=None, read_func='read_csv', read_kwarg
         # TODO: improve check, make it usable with several files.
         matching_paths = glob.glob(globy)
         matches_pattern = os.path.normpath(path) in map(os.path.normpath, matching_paths)
-        # import ipdb; ipdb.set_trace()
-        # is_file = Path(matching_paths).is_file()
         is_file = len(matching_paths) == 1
 
     if path.endswith(".{}".format(file_type)):  # one file and extension is explicite
@@ -79,9 +77,8 @@ def load_df(path, read_func='read_csv', read_kwargs={}):
     else:
         with open(path, 'r') as file:
             data = json.load(file)
-        # import ipdb; ipdb.set_trace()
+
         df = pd.DataFrame(data['records'])
-        # df['data'] = df['data'].fillna({})
         return df
 
 


### PR DESCRIPTION
Added a job to copy raw files from S3 to local, `copy_raw_job.py` , similar to `copy_job.py ` but without loading the file content.
Pro:
 * it allows having a straight copy of s3 files, useful when files are not easy to load.
 * Faster transfer.
Cons: 
 * impossible to change the file format as possible with copy_job.py 

This can be used with glob or with regex to filter which files to copy.
Showcases in new sample job `examples/copy_cloud_to_local_job`.

Other:
 * Added support for pickle
 * Made 'conf/jobs_metadata.yml' arg explicit in all generic jobs.