### PR TITLE
Support single tenancy & more + move to v0.11.8

### DIFF
--- a/conf/aws_config.cfg.example
+++ b/conf/aws_config.cfg.example
@@ -4,7 +4,9 @@ ec2_key_name         : to_be_filled
 user                 : to_be_filled
 s3_region            : to_be_filled
 ec2_subnet_id        : to_be_filled
-extra_security_gp    : None
+extra_security_gp    : to_be_filled # optional
+emr_ec2_role         : to_be_filled # optional
+emr_role             : to_be_filled # optional
 
 [prod]
 profile_name         : to_be_filled
@@ -12,4 +14,6 @@ ec2_key_name         : to_be_filled
 user                 : to_be_filled
 s3_region            : to_be_filled
 ec2_subnet_id        : to_be_filled
-extra_security_gp    : None
+extra_security_gp    : to_be_filled # optional
+emr_ec2_role         : to_be_filled # optional
+emr_role             : to_be_filled # optional

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -348,6 +348,22 @@ jobs:
     dependencies: [examples/ex0_extraction_job.py]
     spark_boot: False
 
+  examples/ex18_base_path_in_out_job:
+    description: |
+      Showing use of name_base_in_param and name_base_out_param, to set base_path different in input and output.
+      usage: python jobs/generic/launcher.py --job_name=examples/ex18_base_path_in_out_job #--mode=dev_local,your_extra_tenant
+    py_job: jobs/examples/ex7_pandas_job.py
+    inputs:
+      some_events: {'path':"{base_path_in}/wiki_example/input/{latest}/", 'type':'csv', 'df_type':'pandas'}
+      other_events: {'path':"{base_path_in}/wiki_example/input/{latest}/", 'type':'csv', 'df_type':'pandas', 'read_kwargs':{}}
+    output: {'path':'{base_path_out}/wiki_example/output_ex7_pandas/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas', 'save_kwargs':{'sep':'|'}}
+    dependencies: [examples/ex0_extraction_job.py]
+    name_base_in_param: base_path_in
+    name_base_out_param: base_path_out
+    base_path_in: './data'
+    base_path_out: './data_other'
+    spark_boot: False
+
   # wordcount_raw_job: #Job exists but doesn't rely on jobs_metadata entries
 
   # ----- Marketing Jobs --------
@@ -461,5 +477,5 @@ common_params:
       save_schemas: True
       manage_git_info: False
     your_extra_tenant:  # useful for single tenant architecture, with data in separate locations
-      root_path: 's3://mylake-tenant2'
+      save_schemas: False
       other_param: 'some_value'

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -336,6 +336,18 @@ jobs:
     output: {'path':'{base_path}/load_example/glob_filtering/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas'}
     spark_boot: False
 
+  examples/ex17_multimode_params_job:
+    description: |
+      Showing how to use multiple, useful for single tenant setup, where base_path need to change for various. see --mode=dev_local,your_extra_tenant below.
+      usage: python jobs/generic/launcher.py --job_name=examples/ex17_multimode_params_job --mode=dev_local,your_extra_tenant
+    py_job: jobs/examples/ex7_pandas_job.py
+    inputs:
+      some_events: {'path':"{base_path}/wiki_example/input/{latest}/", 'type':'csv', 'df_type':'pandas'}
+      other_events: {'path':"{base_path}/wiki_example/input/{latest}/", 'type':'csv', 'df_type':'pandas', 'read_kwargs':{}}
+    output: {'path':'{base_path}/wiki_example/output_ex7_pandas/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas', 'save_kwargs':{'sep':'|'}}
+    dependencies: [examples/ex0_extraction_job.py]
+    spark_boot: False
+
   # wordcount_raw_job: #Job exists but doesn't rely on jobs_metadata entries
 
   # ----- Marketing Jobs --------

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -448,3 +448,6 @@ common_params:
       enable_db_push: False
       save_schemas: True
       manage_git_info: False
+    your_extra_tenant:  # useful for single tenant architecture, with data in separate locations
+      root_path: 's3://mylake-tenant2'
+      other_param: 'some_value'

--- a/conf/jobs_metadata.yml
+++ b/conf/jobs_metadata.yml
@@ -345,7 +345,6 @@ jobs:
       some_events: {'path':"{base_path}/wiki_example/input/{latest}/", 'type':'csv', 'df_type':'pandas'}
       other_events: {'path':"{base_path}/wiki_example/input/{latest}/", 'type':'csv', 'df_type':'pandas', 'read_kwargs':{}}
     output: {'path':'{base_path}/wiki_example/output_ex7_pandas/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas', 'save_kwargs':{'sep':'|'}}
-    dependencies: [examples/ex0_extraction_job.py]
     spark_boot: False
 
   examples/ex18_base_path_in_out_job:
@@ -357,7 +356,6 @@ jobs:
       some_events: {'path':"{base_path_in}/wiki_example/input/{latest}/", 'type':'csv', 'df_type':'pandas'}
       other_events: {'path':"{base_path_in}/wiki_example/input/{latest}/", 'type':'csv', 'df_type':'pandas', 'read_kwargs':{}}
     output: {'path':'{base_path_out}/wiki_example/output_ex7_pandas/{now}/dataset.csv', 'type':'csv', 'df_type':'pandas', 'save_kwargs':{'sep':'|'}}
-    dependencies: [examples/ex0_extraction_job.py]
     name_base_in_param: base_path_in
     name_base_out_param: base_path_out
     base_path_in: './data'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ copyright = '2018, Arthur Prevot'
 author = 'Arthur Prevot'
 
 release = '0.11'
-version = '0.11.7'
+version = '0.11.8'
 
 # -- General configuration
 

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -1,3 +1,6 @@
+"""
+Job meant to run locally to get data from AWS S3 to local. Updates require to run in cluster.
+"""
 from yaetos.etl_utils import ETL_Base, Commandliner, get_aws_setup
 import os
 from cloudpathlib import CloudPath as CPt

--- a/jobs/generic/copy_raw_job.py
+++ b/jobs/generic/copy_raw_job.py
@@ -1,5 +1,5 @@
 """
-Job meant to run locally to get data from AWS S3 to local. Updates require to run in cluster.
+Job meant to run locally to get data from AWS S3 to local. Updates required to run in cluster.
 """
 from yaetos.etl_utils import ETL_Base, Commandliner, get_aws_setup
 import os

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/guides/single-sourcing-package-version/
-    version='0.11.7',  # Required
+    version='0.11.8',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/tests/yaetos/deploy_test.py
+++ b/tests/yaetos/deploy_test.py
@@ -79,8 +79,6 @@ class Test_DeployPySparkScriptOnAws(object):
         assert actual == expected
 
     def test_get_spark_submit_args_with_launcher(self, app_args):
-        # Test base case
-        # app_args['mode'] = 'mode_x'
         app_args['job_name'] = 'some_job_name'
         app_file = 'jobs/generic/launcher.py'
         actual = Dep.get_spark_submit_args(app_file, app_args)
@@ -100,7 +98,6 @@ class Test_DeployPySparkScriptOnAws(object):
             'jar_job': 'some/job.jar',
             'spark_app_args': 'some_arg'}
         app_file = 'jobs/generic/launcher.py'
-        # app_file = app_args['jar_job']
         actual = Dep.get_spark_submit_args(app_file, app_args)
         expected = [
             'spark-submit',

--- a/tests/yaetos/deploy_test.py
+++ b/tests/yaetos/deploy_test.py
@@ -78,11 +78,29 @@ class Test_DeployPySparkScriptOnAws(object):
         expected.insert(8, '--sql_file=/home/hadoop/app/some_file.sql')
         assert actual == expected
 
+    def test_get_spark_submit_args_with_launcher(self, app_args):
+        # Test base case
+        # app_args['mode'] = 'mode_x'
+        app_args['job_name'] = 'some_job_name'
+        app_file = 'jobs/generic/launcher.py'
+        actual = Dep.get_spark_submit_args(app_file, app_args)
+        expected = [
+            'spark-submit',
+            '--verbose',
+            '--py-files=/home/hadoop/app/scripts.zip',
+            '/home/hadoop/app/jobs/generic/launcher.py',
+            '--mode=None',
+            '--deploy=none',
+            '--storage=s3',
+            '--job_name=some_job_name']
+        assert actual == expected
+
     def test_get_spark_submit_args_jar(self):
         app_args = {
             'jar_job': 'some/job.jar',
             'spark_app_args': 'some_arg'}
-        app_file = app_args['jar_job']
+        app_file = 'jobs/generic/launcher.py'
+        # app_file = app_args['jar_job']
         actual = Dep.get_spark_submit_args(app_file, app_args)
         expected = [
             'spark-submit',

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -139,7 +139,6 @@ class Test_Job_Yml_Parser(object):
         assert actual_params == expected_params
 
 
-
 class Test_Job_Args_Parser(object):
     def test_no_param_override(self):
         defaults_args = {'py_job': 'some_job.py', 'mode': 'dev_local', 'deploy': 'code', 'output': {'path': 'n/a', 'type': 'csv'}}

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -132,7 +132,7 @@ class Test_Job_Yml_Parser(object):
         job_param_file = 'conf/jobs_metadata.yml'
         skip_job = True
         expected_params = {
-            'root_path': 's3://mylake-tenant2',
+            'save_schemas': False,
             'other_param': 'some_value'}
         actual_params = Job_Yml_Parser(job_name, job_param_file, yml_modes, skip_job).set_job_yml(job_name, job_param_file, yml_modes, skip_job)
         actual_params = {key: value for (key, value) in actual_params.items() if key in expected_params.keys()}

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -185,8 +185,7 @@ class Test_Runner(object):
         cmd_lst_expected = [
             'spark-submit',
             '--py-files=some/files.zip',
-            'jobs/examples/ex7_pandas_job.py',  # launcher.py not carried over. may want to change behavior.
-            ]
+            'jobs/examples/ex7_pandas_job.py']  # launcher.py not carried over. may want to change behavior.
         assert cmd_lst_real == cmd_lst_expected
 
     def test_create_spark_submit_jar_job(self):

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -173,6 +173,23 @@ class Test_Runner(object):
             '--arg2=value2']
         assert cmd_lst_real == cmd_lst_expected
 
+    def test_create_spark_submit_python_job_with_launcher(self):
+        job_args = {
+            'launcher_file': 'jobs/generic/launcher.py',
+            'py_job': 'jobs/examples/ex7_pandas_job.py',
+            'py-files': 'some/files.zip',
+            'spark_submit_keys': 'py-files',
+            'spark_app_keys': ''}
+        launch_jargs = Job_Args_Parser(defaults_args={}, yml_args={}, job_args=job_args, cmd_args={}, build_yml_args=False, loaded_inputs={})
+        cmd_lst_real = Runner.create_spark_submit(jargs=launch_jargs)
+        cmd_lst_expected = [
+            'spark-submit',
+            '--py-files=some/files.zip',
+            'jobs/examples/ex7_pandas_job.py',  # launcher.py not carried over. may want to change behavior.
+            # '--job_name=some_job',
+            ]
+        assert cmd_lst_real == cmd_lst_expected
+
     def test_create_spark_submit_jar_job(self):
         job_args = {
             'jar_job': 'jobs/examples/ex12_scala_job/target/spark_scala_job_2.13-1.0.jar',

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -100,6 +100,33 @@ class Test_Job_Yml_Parser(object):
         sql_file = Job_Yml_Parser.set_sql_file_from_name('some/job_name')
         assert sql_file is None
 
+    def test_set_mode_specific_params(self):
+        job_name = 'examples/ex0_extraction_job.py'
+        job_param_file = 'conf/jobs_metadata.yml'
+        yml_modes = 'dev_EMR'
+        skip_job = True
+        actual_params = Job_Yml_Parser(job_name, job_param_file, yml_modes, skip_job).set_job_yml(job_name, job_param_file, yml_modes, skip_job)
+        expected_params = {
+            'aws_config_file': 'conf/aws_config.cfg',
+            'aws_setup': 'dev',
+            'base_path': '{root_path}/pipelines_data',
+            'connection_file': 'conf/connections.cfg',
+            'email_cred_section': 'some_email_cred_section',
+            'emr_core_instances': 0,
+            'enable_db_push': False,
+            'jobs_folder': 'jobs/',
+            'load_connectors': 'all',
+            'manage_git_info': True,
+            'redshift_s3_tmp_dir': 's3a://dev-spark/tmp_spark/',
+            'root_path': 's3://mylake-dev',
+            's3_dags': '{root_path}/pipelines_metadata/airflow_dags',
+            's3_logs': '{root_path}/pipelines_metadata',
+            'save_schemas': False,
+            'schema': 'sandbox',
+            'spark_version': '3.5'}
+        assert actual_params == expected_params
+
+
 
 class Test_Job_Args_Parser(object):
     def test_no_param_override(self):

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -101,7 +101,7 @@ class Test_Job_Yml_Parser(object):
         assert sql_file is None
 
     def test_set_mode_specific_params(self):
-        job_name = 'examples/ex0_extraction_job.py'
+        job_name = 'n/a'
         job_param_file = 'conf/jobs_metadata.yml'
         yml_modes = 'dev_EMR'
         skip_job = True
@@ -124,6 +124,18 @@ class Test_Job_Yml_Parser(object):
             'save_schemas': False,
             'schema': 'sandbox',
             'spark_version': '3.5'}
+        assert actual_params == expected_params
+
+    def test_set_modes(self):
+        yml_modes = 'dev_EMR,your_extra_tenant'  # i.e. using 2 modes
+        job_name = 'n/a'
+        job_param_file = 'conf/jobs_metadata.yml'
+        skip_job = True
+        expected_params = {
+            'root_path': 's3://mylake-tenant2',
+            'other_param': 'some_value'}
+        actual_params = Job_Yml_Parser(job_name, job_param_file, yml_modes, skip_job).set_job_yml(job_name, job_param_file, yml_modes, skip_job)
+        actual_params = {key: value for (key, value) in actual_params.items() if key in expected_params.keys()}
         assert actual_params == expected_params
 
 

--- a/tests/yaetos/etl_utils_test.py
+++ b/tests/yaetos/etl_utils_test.py
@@ -186,7 +186,6 @@ class Test_Runner(object):
             'spark-submit',
             '--py-files=some/files.zip',
             'jobs/examples/ex7_pandas_job.py',  # launcher.py not carried over. may want to change behavior.
-            # '--job_name=some_job',
             ]
         assert cmd_lst_real == cmd_lst_expected
 

--- a/yaetos/athena.py
+++ b/yaetos/athena.py
@@ -41,7 +41,7 @@ def register_table(types, name_tb, schema, output_info, args):
         raise Exception('Athena table registration not setup for other than csv files.')
 
     # Start the query execution
-    if args.get('mode') == 'dev_local':
+    if args.get('mode') and 'dev_local' in args['mode'].split(','):
         config = ConfigParser()
         assert os.path.isfile(args.get('aws_config_file'))
         config.read(args.get('aws_config_file'))

--- a/yaetos/athena.py
+++ b/yaetos/athena.py
@@ -55,7 +55,7 @@ def register_table_to_athena_catalog(types, name_tb, schema, output_info, args):
         QueryExecutionContext={'Database': schema},
         ResultConfiguration={'OutputLocation': args.get('athena_out')},
     )
-    logger.info(f"Registered table to athena '{schema}.{name_tb}', with QueryExecutionId: {response['QueryExecutionId']}.")
+    logger.info(f"Registered table to athena '{schema}.{name_tb}', pointing to {output_folder}, with QueryExecutionId: {response['QueryExecutionId']}.")
     # TODO: Check to support "is_incremental"
 
 
@@ -100,16 +100,13 @@ def register_table_to_glue_catalog(schema_list, name_tb, schema, output_info, ar
     }
 
     try:
-        # Try deleting the table first
         glue_client.delete_table(DatabaseName=database_name, Name=table_name)
         print("Existing table deleted.")
     except glue_client.exceptions.EntityNotFoundException:
         print("No table to delete.")
 
-    # Create or update the table in Glue Catalog
     response = glue_client.create_table(
         DatabaseName=database_name,
         TableInput=table_input
     )
-    # logger.info(f"Registered table to athena '{schema}.{name_tb}', with QueryExecutionId: {response['QueryExecutionId']}.")
-    logger.info(f"Registered table to athena '{schema}.{name_tb}', with query response: {response}.")
+    logger.info(f"Registered table to athena '{schema}.{name_tb}', pointing to {output_folder} with query response: {response}.")

--- a/yaetos/athena.py
+++ b/yaetos/athena.py
@@ -59,7 +59,7 @@ def register_table(types, name_tb, schema, output_info, args):
     # TODO: Check to support "is_incremental"
 
 
-def register_table_sdf(df, name_tb, schema, output_info, args):
+def register_table_from_sdf_to_glue(df, name_tb, schema, output_info, args):
     output_folder = output_info['path_expanded'].replace('s3a', 's3')
 
     # Start the query execution

--- a/yaetos/athena.py
+++ b/yaetos/athena.py
@@ -70,7 +70,7 @@ def register_table_from_sdf_to_glue_catalog(schema_list, name_tb, schema, output
         region_name = config.get(args.get('aws_setup'), 's3_region')
     else:
         region_name = boto3.Session().region_name
-    
+
     # glue_client = boto3.client('glue')
     glue_client = boto3.client('glue', region_name=region_name)
 

--- a/yaetos/athena.py
+++ b/yaetos/athena.py
@@ -57,3 +57,88 @@ def register_table(types, name_tb, schema, output_info, args):
     )
     logger.info(f"Registered table to athena '{schema}.{name_tb}', with QueryExecutionId: {response['QueryExecutionId']}.")
     # TODO: Check to support "is_incremental"
+
+
+def register_table_sdf(df, name_tb, schema, output_info, args):
+    output_folder = output_info['path_expanded'].replace('s3a', 's3')
+
+    # Start the query execution
+    if args.get('mode') == 'dev_local':
+        config = ConfigParser()
+        assert os.path.isfile(args.get('aws_config_file'))
+        config.read(args.get('aws_config_file'))
+        region_name = config.get(args.get('aws_setup'), 's3_region')
+    else:
+        region_name = boto3.Session().region_name
+    
+    # glue_client = boto3.client('glue')
+    glue_client = boto3.client('glue', region_name=region_name)
+
+    database_name = schema  # The Glue database to add the table to
+    table_name = name_tb        # The new table name
+    schema_list = [{"Name": field.name, "Type": convert_data_type(field.dataType)} for field in df.schema]
+    logger.info(f"Registering table to athena '{schema}.{name_tb}', schema {schema_list}.")
+
+    # Define the table input
+    table_input = {
+        'Name': table_name,
+        'StorageDescriptor': {
+            # 'Columns': [
+            #     {'Name': 'name', 'Type': 'string'},
+            #     {'Name': 'age', 'Type': 'int'}
+            # ],
+            'Columns': schema_list,
+            'Location': output_folder,
+            'InputFormat': 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat',
+            'OutputFormat': 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat',
+            'Compressed': False,
+            'SerdeInfo': {
+                'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe',
+                'Parameters': {
+                    'serialization.format': '1'
+                }
+            },
+        },
+        'TableType': 'EXTERNAL_TABLE',
+        'Parameters': {
+            'classification': 'parquet'
+        }
+    }
+
+    try:
+        # Try deleting the table first
+        glue_client.delete_table(DatabaseName=database_name, Name=table_name)
+        print("Existing table deleted.")
+    except glue_client.exceptions.EntityNotFoundException:
+        print("No table to delete.")
+
+    # Create or update the table in Glue Catalog
+    response = glue_client.create_table(
+        DatabaseName=database_name,
+        TableInput=table_input
+    )
+    # logger.info(f"Registered table to athena '{schema}.{name_tb}', with QueryExecutionId: {response['QueryExecutionId']}.")
+    logger.info(f"Registered table to athena '{schema}.{name_tb}', with query response: {response}.")
+
+
+def convert_data_type(data_type):
+    """ Convert Spark data types to a detailed readable string format, handling nested structures. """
+    from pyspark.sql.types import StructType, StructField, IntegerType, StringType, ArrayType, FloatType, DecimalType, TimestampType
+
+    if isinstance(data_type, StructType):
+        # Handle nested struct by recursively processing each field
+        fields = [f"{field.name}: {convert_data_type(field.dataType)}" for field in data_type.fields]
+        return f"struct<{', '.join(fields)}>"
+    elif isinstance(data_type, ArrayType):
+        # Handle arrays by describing element types
+        element_type = convert_data_type(data_type.elementType)
+        return f"array<{element_type}>"
+    elif isinstance(data_type, TimestampType):
+        return "timestamp"
+    elif isinstance(data_type, FloatType):
+        return "float"
+    elif isinstance(data_type, DecimalType):
+        return f"decimal({data_type.precision},{data_type.scale})"
+    else:
+        # Fallback for other types with default string representation
+        return data_type.simpleString()

--- a/yaetos/athena.py
+++ b/yaetos/athena.py
@@ -6,7 +6,7 @@ from yaetos.logger import setup_logging
 logger = setup_logging('Athena')
 
 
-def register_table_from_pdf_to_athena_catalog(types, name_tb, schema, output_info, args):
+def register_table_to_athena_catalog(types, name_tb, schema, output_info, args):
     description_statement = f"""COMMENT "{args['description']}" """ if args.get('description') else ''
     output_folder = output_info['path_expanded'].replace('s3a', 's3')
 
@@ -59,7 +59,7 @@ def register_table_from_pdf_to_athena_catalog(types, name_tb, schema, output_inf
     # TODO: Check to support "is_incremental"
 
 
-def register_table_from_sdf_to_glue_catalog(schema_list, name_tb, schema, output_info, args):
+def register_table_to_glue_catalog(schema_list, name_tb, schema, output_info, args):
     output_folder = output_info['path_expanded'].replace('s3a', 's3')
 
     # Start the query execution
@@ -71,21 +71,16 @@ def register_table_from_sdf_to_glue_catalog(schema_list, name_tb, schema, output
     else:
         region_name = boto3.Session().region_name
 
-    # glue_client = boto3.client('glue')
     glue_client = boto3.client('glue', region_name=region_name)
 
-    database_name = schema  # The Glue database to add the table to
-    table_name = name_tb        # The new table name
+    database_name = schema
+    table_name = name_tb
     logger.info(f"Registering table to athena '{schema}.{name_tb}', schema {schema_list}.")
 
     # Define the table input
     table_input = {
         'Name': table_name,
         'StorageDescriptor': {
-            # 'Columns': [
-            #     {'Name': 'name', 'Type': 'string'},
-            #     {'Name': 'age', 'Type': 'int'}
-            # ],
             'Columns': schema_list,
             'Location': output_folder,
             'InputFormat': 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat',

--- a/yaetos/db_utils.py
+++ b/yaetos/db_utils.py
@@ -161,7 +161,7 @@ def pandas_types_to_hive_types(df, format='glue'):
 
 def spark_type_to_hive_type(data_type):
     """ Convert Spark data types to a detailed readable string format, handling nested structures. """
-    from pyspark.sql.types import StructType, ArrayType, FloatType, DecimalType, TimestampType  # StructField, IntegerType, StringType, 
+    from pyspark.sql.types import StructType, ArrayType, FloatType, DecimalType, TimestampType  # StructField, IntegerType, StringType,
 
     if isinstance(data_type, StructType):
         # Handle nested struct by recursively processing each field

--- a/yaetos/db_utils.py
+++ b/yaetos/db_utils.py
@@ -145,7 +145,7 @@ def pandas_types_to_hive_types(df):
         # 'decimal': 'DECIMAL',
     }
     hive_types = {}
-    for column, dtype in df.dtypes.iteritems():
+    for column, dtype in df.dtypes.items():
         dtype_name = dtype.name
         hive_type = type_mapping.get(dtype_name, 'STRING')  # Default to STRING if no mapping found
         hive_types[column] = hive_type

--- a/yaetos/db_utils.py
+++ b/yaetos/db_utils.py
@@ -118,6 +118,7 @@ def pandas_types_to_hive_types(df, format='glue'):
     :param df: pandas DataFrame
     :return: Dictionary or list of dictionaries of column names and their Hive data types
     """
+    # TODO: add support for nested fields, just like in spark version
     type_mapping = {
         'object': 'STRING',
         'bool': 'BOOLEAN',

--- a/yaetos/db_utils.py
+++ b/yaetos/db_utils.py
@@ -151,9 +151,10 @@ def pandas_types_to_hive_types(df):
         hive_types[column] = hive_type
     return hive_types
 
+
 def spark_type_to_hive_type(data_type):
     """ Convert Spark data types to a detailed readable string format, handling nested structures. """
-    from pyspark.sql.types import StructType, StructField, IntegerType, StringType, ArrayType, FloatType, DecimalType, TimestampType
+    from pyspark.sql.types import StructType, ArrayType, FloatType, DecimalType, TimestampType  # StructField, IntegerType, StringType, 
 
     if isinstance(data_type, StructType):
         # Handle nested struct by recursively processing each field
@@ -172,6 +173,7 @@ def spark_type_to_hive_type(data_type):
     else:
         # Fallback for other types with default string representation
         return data_type.simpleString()
+
 
 def spark_types_to_hive_types(sdf):
     schema_list = [{"Name": field.name, "Type": spark_type_to_hive_type(field.dataType)} for field in sdf.schema]

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -111,7 +111,7 @@ class DeployPySparkScriptOnAws(object):
             raise Exception("Shouldn't get here.")
 
     def continue_post_git_check(self):
-        if self.app_args['mode'] != 'prod_EMR':
+        if 'prod_EMR' not in self.app_args['mode'].split(',') :
             logger.debug('Not pushing as "prod_EMR", so git check ignored')
             return True
         elif self.git_yml is None:
@@ -237,7 +237,7 @@ class DeployPySparkScriptOnAws(object):
         return pipeline_name.split('__')[2].replace('_d_', '.').replace('_s_', '/') if '__' in pipeline_name else None
 
     def get_job_log_path(self):
-        if self.deploy_args.get('mode') == 'prod_EMR':
+        if self.deploy_args.get('mode') and 'prod_EMR' in self.deploy_args.get('mode').split(',') :  # TODO: check if should be replaced by app_args
             return '{}/jobs_code/production'.format(self.metadata_folder)
         else:
             return '{}/jobs_code/{}'.format(self.metadata_folder, self.pipeline_name)

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -357,7 +357,7 @@ class DeployPySparkScriptOnAws(object):
             base = Pt(eu.LOCAL_FRAMEWORK_FOLDER)
         elif self.app_args['code_source'] == 'dir':
             base = Pt(self.app_args['code_source_path'])
-        logger.debug("Source of yaetos code to be shipped: {}".format(base / 'yaetos/'))
+        logger.info("Source of yaetos code to be shipped: {}".format(base / 'yaetos/'))
         # TODO: move code_source and code_source_path to deploy_args, involves adding it to DEPLOY_ARGS_LIST
         return base
 

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -431,8 +431,8 @@ class DeployPySparkScriptOnAws(object):
                 # "Properties": { "spark.jars": ["/home/hadoop/redshift_tbd.jar"], "spark.driver.memory": "40G", "maximizeResourceAllocation": "true"},
                 # }
             ],
-            JobFlowRole= self.emr_ec2_role, #'EMR_EC2_DefaultRole',
-            ServiceRole= self.emr_role, # 'EMR_DefaultRole',
+            JobFlowRole=self.emr_ec2_role,
+            ServiceRole=self.emr_role,
             VisibleToAllUsers=True,
             BootstrapActions=[{
                 'Name': 'setup_nodes',

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -61,7 +61,11 @@ class DeployPySparkScriptOnAws(object):
         self.ec2_instance_master = app_args.get('ec2_instance_master', 'm5.xlarge')  # 'm5.12xlarge', # used m3.2xlarge (8 vCPU, 30 Gib RAM), and earlier m3.xlarge (4 vCPU, 15 Gib RAM)
         self.ec2_instance_slaves = app_args.get('ec2_instance_slaves', 'm5.xlarge')
         # Paths
-        self.s3_logs = CPt(app_args.get('s3_logs', 's3://').replace('{root_path}', self.app_args.get('root_path', '')))
+        # self.s3_logs = CPt(app_args.get('s3_logs', 's3://').replace('{root_path}', self.app_args.get('root_path', '')))
+        s3_logs = app_args.get('s3_logs', 's3://').replace('{root_path}', self.app_args.get('root_path', ''))
+        print('#### ------', s3_logs)
+        self.s3_logs = CPt(s3_logs)
+
         self.s3_bucket_logs = self.s3_logs.bucket
         self.metadata_folder = 'pipelines_metadata'  # TODO remove
         self.pipeline_name = self.generate_pipeline_name(self.deploy_args['mode'], self.app_args['job_name'], self.user)  # format: some_job.some_user.20181204.153429
@@ -525,7 +529,7 @@ class DeployPySparkScriptOnAws(object):
                 'spark_submit_keys': 'py-files',
                 'spark_app_args': '',
                 'spark_app_keys': 'mode--deploy--storage'}
-        else:
+        else:  # for jar
             overridable_args = {
                 'spark_submit_args': '--verbose',
                 'spark_submit_keys': '',

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -215,15 +215,15 @@ class DeployPySparkScriptOnAws(object):
     def generate_pipeline_name(mode, job_name, user):
         """Opposite of get_job_name()"""
 
-        # Get deploy_env (Hacky. TODO: improve) 
+        # Get deploy_env (Hacky. TODO: improve)
         modes = mode.split(',')
         required_mode = ('dev_EMR', 'prod_EMR')
         modes = [item for item in modes if item in required_mode]
-        if len(modes) == 1: 
+        if len(modes) == 1:
             deploy_env = modes[0]
         else:
             raise Exception(f"mode missing one of the required on {required_mode}")
-        
+
         mode_label = {'dev_EMR': 'dev', 'prod_EMR': 'prod'}[deploy_env]
         pname = job_name.replace('.', '_d_').replace('/', '_s_')
         now = datetime.now().strftime("%Y%m%dT%H%M%S")

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -56,6 +56,8 @@ class DeployPySparkScriptOnAws(object):
         self.profile_name = config.get(aws_setup, 'profile_name')
         self.ec2_subnet_id = config.get(aws_setup, 'ec2_subnet_id')
         self.extra_security_gp = config.get(aws_setup, 'extra_security_gp')
+        self.emr_ec2_role = config.get(aws_setup, 'emr_ec2_role', fallback='EMR_EC2_DefaultRole')
+        self.emr_role = config.get(aws_setup, 'emr_role', fallback='EMR_DefaultRole')
         self.emr_core_instances = int(app_args.get('emr_core_instances', 1))  # TODO: make this update EMR_Scheduled mode too.
         self.deploy_args = deploy_args
         self.ec2_instance_master = app_args.get('ec2_instance_master', 'm5.xlarge')  # 'm5.12xlarge', # used m3.2xlarge (8 vCPU, 30 Gib RAM), and earlier m3.xlarge (4 vCPU, 15 Gib RAM)
@@ -430,8 +432,8 @@ class DeployPySparkScriptOnAws(object):
                 # "Properties": { "spark.jars": ["/home/hadoop/redshift_tbd.jar"], "spark.driver.memory": "40G", "maximizeResourceAllocation": "true"},
                 # }
             ],
-            JobFlowRole='EMR_EC2_DefaultRole',
-            ServiceRole='EMR_DefaultRole',
+            JobFlowRole= self.emr_ec2_role, #'EMR_EC2_DefaultRole',
+            ServiceRole= self.emr_role, # 'EMR_DefaultRole',
             VisibleToAllUsers=True,
             BootstrapActions=[{
                 'Name': 'setup_nodes',

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -534,13 +534,29 @@ class DeployPySparkScriptOnAws(object):
 
         overridable_args.update(app_args)
         args = overridable_args.copy()
+
+        # set py_job
+        if app_args.get('launcher_file') and app_args.get('py_job'):
+            py_job = eu.CLUSTER_APP_FOLDER + app_args.get('launcher_file')
+        elif isinstance(app_file, str) and app_file.endswith('.py'):  # TODO: check values app_file can take
+            py_job = eu.CLUSTER_APP_FOLDER + app_file
+        else:
+            py_job = None
+
+        # set jar_job
+        if app_args.get('launcher_file') and app_args.get('jar_job'):
+            jar_job = eu.CLUSTER_APP_FOLDER + app_args.get('launcher_file')
+        else:
+            jar_job = None
+        # TODO: simplify business of getting application code (2 blocks up) upstream, in etl_utils.py
+
         unoverridable_args = {
-            'py-files': f"{eu.CLUSTER_APP_FOLDER}scripts.zip",
-            'py_job': eu.CLUSTER_APP_FOLDER + (app_file or app_args.get('py_job') or app_args.get('launcher_file')),  # TODO: simplify business of getting application code upstream
+            'py-files': f"{eu.CLUSTER_APP_FOLDER}scripts.zip" if py_job else None,
+            'py_job': py_job,
             'mode': 'dev_EMR' if app_args.get('mode') == 'dev_local' else app_args.get('mode'),
             'deploy': 'none',
             'storage': 's3',
-            'jar_job': eu.CLUSTER_APP_FOLDER + (app_file or app_args.get('jar_job') or app_args.get('launcher_file'))}
+            'jar_job': jar_job}
         args.update(unoverridable_args)
 
         if app_args.get('load_connectors', '') == 'all':

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -570,7 +570,7 @@ class DeployPySparkScriptOnAws(object):
         unoverridable_args = {
             'py-files': f"{eu.CLUSTER_APP_FOLDER}scripts.zip" if py_job else None,
             'py_job': py_job,
-            'mode': 'dev_EMR' if app_args.get('mode') == 'dev_local' else app_args.get('mode'),
+            'mode': 'dev_EMR' if app_args.get('mode') and 'dev_local' in app_args['mode'].split(',') else app_args.get('mode'),
             'deploy': 'none',
             'storage': 's3',
             'jar_job': jar_job}

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -50,24 +50,23 @@ class DeployPySparkScriptOnAws(object):
         self.app_args = app_args
         self.app_file = app_args['py_job']  # TODO: remove all refs to app_file to be consistent.
         self.aws_setup = aws_setup
+        # From aws_config.cfg:
         self.ec2_key_name = config.get(aws_setup, 'ec2_key_name')
         self.s3_region = config.get(aws_setup, 's3_region')
         self.user = config.get(aws_setup, 'user')
         self.profile_name = config.get(aws_setup, 'profile_name')
         self.ec2_subnet_id = config.get(aws_setup, 'ec2_subnet_id')
-        self.extra_security_gp = config.get(aws_setup, 'extra_security_gp')
+        self.extra_security_gp = config.get(aws_setup, 'extra_security_gp', fallback=None)
         self.emr_ec2_role = config.get(aws_setup, 'emr_ec2_role', fallback='EMR_EC2_DefaultRole')
         self.emr_role = config.get(aws_setup, 'emr_role', fallback='EMR_DefaultRole')
+        # From jobs_metadata.yml:
         self.emr_core_instances = int(app_args.get('emr_core_instances', 1))  # TODO: make this update EMR_Scheduled mode too.
         self.deploy_args = deploy_args
         self.ec2_instance_master = app_args.get('ec2_instance_master', 'm5.xlarge')  # 'm5.12xlarge', # used m3.2xlarge (8 vCPU, 30 Gib RAM), and earlier m3.xlarge (4 vCPU, 15 Gib RAM)
         self.ec2_instance_slaves = app_args.get('ec2_instance_slaves', 'm5.xlarge')
-        # Paths
-        # self.s3_logs = CPt(app_args.get('s3_logs', 's3://').replace('{root_path}', self.app_args.get('root_path', '')))
+        # Computed params:
         s3_logs = app_args.get('s3_logs', 's3://').replace('{root_path}', self.app_args.get('root_path', ''))
-        print('#### ------', s3_logs)
         self.s3_logs = CPt(s3_logs)
-
         self.s3_bucket_logs = self.s3_logs.bucket
         self.metadata_folder = 'pipelines_metadata'  # TODO remove
         self.pipeline_name = self.generate_pipeline_name(self.deploy_args['mode'], self.app_args['job_name'], self.user)  # format: some_job.some_user.20181204.153429

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -214,7 +214,17 @@ class DeployPySparkScriptOnAws(object):
     @staticmethod
     def generate_pipeline_name(mode, job_name, user):
         """Opposite of get_job_name()"""
-        mode_label = {'dev_EMR': 'dev', 'prod_EMR': 'prod'}[mode]
+
+        # Get deploy_env (Hacky. TODO: improve) 
+        modes = mode.split(',')
+        required_mode = ('dev_EMR', 'prod_EMR')
+        modes = [item for item in modes if item in required_mode]
+        if len(modes) == 1: 
+            deploy_env = modes[0]
+        else:
+            raise Exception(f"mode missing one of the required on {required_mode}")
+        
+        mode_label = {'dev_EMR': 'dev', 'prod_EMR': 'prod'}[deploy_env]
         pname = job_name.replace('.', '_d_').replace('/', '_s_')
         now = datetime.now().strftime("%Y%m%dT%H%M%S")
         name = f"yaetos__{mode_label}__{pname}__{now}"

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -523,13 +523,15 @@ class DeployPySparkScriptOnAws(object):
 
     @staticmethod
     def get_spark_submit_args(app_file, app_args):
+        """ app_file is launcher, might be py_job too, but may also be separate from py_job (ex python launcher.py --job_name=some_job_with_py_job)."""
+
         if app_args.get('py_job'):
             overridable_args = {
                 'spark_submit_args': '--verbose',
                 'spark_submit_keys': 'py-files',
                 'spark_app_args': '',
                 'spark_app_keys': 'mode--deploy--storage'}
-        else:  # for jar
+        else:  # for jar_job
             overridable_args = {
                 'spark_submit_args': '--verbose',
                 'spark_submit_keys': '',
@@ -548,8 +550,8 @@ class DeployPySparkScriptOnAws(object):
             py_job = None
 
         # set jar_job
-        if app_args.get('launcher_file') and app_args.get('jar_job'):
-            jar_job = eu.CLUSTER_APP_FOLDER + app_args.get('launcher_file')
+        if (app_args.get('launcher_file') or isinstance(app_file, str)) and app_args.get('jar_job'):  # TODO: check to enforce app_args.get('launcher_file')
+            jar_job = eu.CLUSTER_APP_FOLDER + app_args.get('jar_job')
         else:
             jar_job = None
         # TODO: simplify business of getting application code (2 blocks up) upstream, in etl_utils.py

--- a/yaetos/deploy.py
+++ b/yaetos/deploy.py
@@ -111,7 +111,7 @@ class DeployPySparkScriptOnAws(object):
             raise Exception("Shouldn't get here.")
 
     def continue_post_git_check(self):
-        if 'prod_EMR' not in self.app_args['mode'].split(',') :
+        if 'prod_EMR' not in self.app_args['mode'].split(','):
             logger.debug('Not pushing as "prod_EMR", so git check ignored')
             return True
         elif self.git_yml is None:
@@ -237,7 +237,7 @@ class DeployPySparkScriptOnAws(object):
         return pipeline_name.split('__')[2].replace('_d_', '.').replace('_s_', '/') if '__' in pipeline_name else None
 
     def get_job_log_path(self):
-        if self.deploy_args.get('mode') and 'prod_EMR' in self.deploy_args.get('mode').split(',') :  # TODO: check if should be replaced by app_args
+        if self.deploy_args.get('mode') and 'prod_EMR' in self.deploy_args.get('mode').split(','):  # TODO: check if should be replaced by app_args
             return '{}/jobs_code/production'.format(self.metadata_folder)
         else:
             return '{}/jobs_code/{}'.format(self.metadata_folder, self.pipeline_name)

--- a/yaetos/env_dispatchers.py
+++ b/yaetos/env_dispatchers.py
@@ -156,17 +156,11 @@ class FS_Ops_Dispatcher():
         cp = CloudPath(fname)  # no need to specify profile_name as aws creds taken from cluster env.
         if globy:
             cfiles = cp.glob(globy)  # careful to loop through cfiles only once as it will be consumed.
-            # print('####----- load_pandas_cluster files 1', list(cfiles))
-            # cfiles = cp.glob(globy)
             os.makedirs(local_path, exist_ok=True)
             logger.info(f"Copying files from S3 '{fname}' to local '{local_path}'")
-            # cfiles = cp.glob(globy)
             for cfile in cfiles:
-                # print('####----- load_pandas_cluster file copy 2', cfile.parent, fname, cfile.name)
                 glob_folders = str(cfile.parent).replace(fname, '')  # goes from s3://some_bucket/path/folder_from_glob/file.parquet to /folder_from_glob/file.parquet
-                # print('####----- load_pandas_cluster file copy 2', cfile.parent, fname, glob_folders, cfile.name)
                 os.makedirs(os.path.join(local_path, glob_folders), exist_ok=True)
-                # local_path2 = 
                 local_file_path = os.path.join(local_path, glob_folders, cfile.name)
                 local_pathlib = cfile.download_to(local_file_path)
             local_path += '/'

--- a/yaetos/env_dispatchers.py
+++ b/yaetos/env_dispatchers.py
@@ -150,16 +150,16 @@ class FS_Ops_Dispatcher():
 
         bucket_name, bucket_fname, fname_parts = self.split_s3_path(fname)
         uuid_path = str(uuid.uuid4())
-        local_path = 'tmp/s3_copy_' + uuid_path + '_' + fname_parts[-1] + '/' + fname_parts[-1]  # First fname_parts[-1] is to show fname part in folder name for easier debugging in AWS. Second is to isolate fname part in sub folder.
-        local_folder = 'tmp/s3_copy_' + uuid_path + '_' + fname_parts[-1]  # to be based on above
+        local_folder = 'tmp/s3_copy_' + uuid_path + '_' + fname_parts[-1]  # fname_parts[-1] put in folder name for easier debugging in AWS.
+        local_path = local_folder + '/' + fname_parts[-1]
         os.makedirs(local_folder, exist_ok=True)
-        cp = CloudPath(fname)  # TODO: add way to load it with specific profile_name or client, as in "s3c = boto3.Session(profile_name='default').client('s3')"
+        cp = CloudPath(fname)  # no need to specify profile_name as aws creds taken from cluster env.
         if globy:
-            cfiles = cp.glob(globy)
+            cfiles = cp.glob(globy)  # careful to loop through cfiles only once as it will be consumed.
             # print('####----- load_pandas_cluster files 1', list(cfiles))
             # cfiles = cp.glob(globy)
             os.makedirs(local_path, exist_ok=True)
-            logger.info(f"Copying files from S3 '{fname}' to local '{local_path}'")  # don't put "Copying {len(list(cfiles))} files" or it will consume generator.
+            logger.info(f"Copying files from S3 '{fname}' to local '{local_path}'")
             # cfiles = cp.glob(globy)
             for cfile in cfiles:
                 # print('####----- load_pandas_cluster file copy 2', cfile.parent, fname, cfile.name)

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -713,22 +713,18 @@ class ETL_Base(object):
         create_table(sdf, connection_profile, name_tb, schema, creds, self.jargs.is_incremental, self.jargs.redshift_s3_tmp_dir, self.jargs.merged_args.get('spark_version', '3.5'))
 
     def register_to_athena(self, df):
-        from yaetos.athena import register_table, register_table_sdf
+        from yaetos.athena import register_table, register_table_from_sdf_to_glue
         from yaetos.db_utils import pandas_types_to_hive_types
         schema, name_tb = self.jargs.register_to_athena['table'].split('.')
         schema = schema.format(schema=self.jargs.schema) if '{schema}' in schema else schema
         output_info = self.jargs.output
-        # pdf = df if isinstance(df, pd.DataFrame) else df.limit(10).toPandas()
-        # hive_types = pandas_types_to_hive_types(pdf)
-        # args = self.jargs.merged_args
-        # register_table(hive_types, name_tb, schema, output_info, args)
         if isinstance(df, pd.DataFrame):
-            hive_types = pandas_types_to_hive_types(pdf)
+            hive_types = pandas_types_to_hive_types(df)
             args = self.jargs.merged_args
             register_table(hive_types, name_tb, schema, output_info, args)
         else:
             args = self.jargs.merged_args
-            register_table_sdf(df, name_tb, schema, output_info, args)
+            register_table_from_sdf_to_glue(df, name_tb, schema, output_info, args)
 
 
     def copy_to_clickhouse(self, sdf):

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1030,7 +1030,7 @@ class Path_Handler():
         path = self.path
         if '{now}' in path:
             current_time = now_dt.strftime('date%Y%m%d_time%H%M%S_utc')
-            path = path.format(now=current_time)
+            path = path.replace('{now}', current_time)
         return path
 
     def get_base(self):

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -237,15 +237,15 @@ class ETL_Base(object):
             job_name = Job_Yml_Parser.set_job_name_from_file(py_job)
         else:
             job_name = pre_jargs['job_args']['job_name']
-        
+
         # Set jargs
         jargs = Job_Args_Parser(
-            defaults_args=pre_jargs['defaults_args'], 
-            yml_args=None, 
-            job_args=pre_jargs['job_args'], 
-            cmd_args=pre_jargs['cmd_args'], 
-            job_name=job_name, 
-            build_yml_args=True, 
+            defaults_args=pre_jargs['defaults_args'],
+            yml_args=None,
+            job_args=pre_jargs['job_args'],
+            cmd_args=pre_jargs['cmd_args'],
+            job_name=job_name,
+            build_yml_args=True,
             loaded_inputs=loaded_inputs)
 
         # Room for jargs mods at job level.

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -862,22 +862,15 @@ class Job_Yml_Parser():
             job_yml = yml['jobs'][job_name]
 
         yml_modes = yml_modes.split(',')
-        if yml_modes == 1:  # regular case
-            yml_mode = yml_modes[0]
+        mode_spec_yml = {}
+        for yml_mode in yml_modes:
             if yml_mode not in yml['common_params']['mode_specific_params']:
                 raise KeyError("Your yml mode '{}' can't be found in jobs_metadata file '{}'. Add it there or make sure the name matches".format(yml_mode, job_param_file))
 
-            mode_spec_yml = yml['common_params']['mode_specific_params'][yml_mode]
-        else:
-            mode_spec_yml = {}
-            for yml_mode in yml_modes:
-                if yml_mode not in yml['common_params']['mode_specific_params']:
-                    raise KeyError("Your yml mode '{}' can't be found in jobs_metadata file '{}'. Add it there or make sure the name matches".format(yml_mode, job_param_file))
+            mode_spec = yml['common_params']['mode_specific_params'][yml_mode]
+            mode_spec_yml.update(mode_spec)
 
-                mode_spec = yml['common_params']['mode_specific_params'][yml_mode]
-                mode_spec_yml.update(mode_spec)
-
-
+        # Stacking params in right order (all_mode_params->mode_specific_params->job_params)
         out = yml['common_params']['all_mode_params']
         out.update(mode_spec_yml)
         out.update(job_yml)
@@ -1105,7 +1098,6 @@ class Runner():
         # Defaults should not be set in parser so they can be set outside of command line functionality.
         parser = argparse.ArgumentParser()
         parser.add_argument("-d", "--deploy", choices=set(['none', 'EMR', 'EMR_Scheduled', 'airflow', 'EMR_DataPipeTest', 'code', 'local_spark_submit']), help="Choose where to run the job.")
-        # parser.add_argument("-m", "--mode", choices=set(['dev_local', 'dev_EMR', 'prod_EMR']), help="Choose which set of params to use from jobs_metadata.yml file.")
         parser.add_argument("-m", "--mode", help="Choose which set of params to use from jobs_metadata.yml file. Typically from ('dev_local', 'dev_EMR', 'prod_EMR') but could include others.")
         parser.add_argument("-j", "--job_param_file", help="Identify file to use. It can be set to 'False' to not load any file and provide all parameters through job or command line arguments.")
         parser.add_argument("-n", "--job_name", help="Identify registry job to use.")

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1268,7 +1268,7 @@ class Runner():
 
 def get_aws_setup(args):
     if os.environ.get('AWS_ACCESS_KEY_ID') and os.environ.get('AWS_SECRET_ACCESS_KEY'):
-        session = boto3.Session()
+        session = boto3.Session()  # to check : credentials = session.get_credentials(); print(credentials.access_key); print(credentials.secret_key)
         return session
 
     from configparser import ConfigParser

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -713,15 +713,23 @@ class ETL_Base(object):
         create_table(sdf, connection_profile, name_tb, schema, creds, self.jargs.is_incremental, self.jargs.redshift_s3_tmp_dir, self.jargs.merged_args.get('spark_version', '3.5'))
 
     def register_to_athena(self, df):
-        from yaetos.athena import register_table
+        from yaetos.athena import register_table, register_table_sdf
         from yaetos.db_utils import pandas_types_to_hive_types
         schema, name_tb = self.jargs.register_to_athena['table'].split('.')
         schema = schema.format(schema=self.jargs.schema) if '{schema}' in schema else schema
         output_info = self.jargs.output
-        pdf = df if isinstance(df, pd.DataFrame) else df.toPandas()
-        hive_types = pandas_types_to_hive_types(pdf)
-        args = self.jargs.merged_args
-        register_table(hive_types, name_tb, schema, output_info, args)
+        # pdf = df if isinstance(df, pd.DataFrame) else df.limit(10).toPandas()
+        # hive_types = pandas_types_to_hive_types(pdf)
+        # args = self.jargs.merged_args
+        # register_table(hive_types, name_tb, schema, output_info, args)
+        if isinstance(df, pd.DataFrame):
+            hive_types = pandas_types_to_hive_types(pdf)
+            args = self.jargs.merged_args
+            register_table(hive_types, name_tb, schema, output_info, args)
+        else:
+            args = self.jargs.merged_args
+            register_table_sdf(df, name_tb, schema, output_info, args)
+
 
     def copy_to_clickhouse(self, sdf):
         # import put here below to avoid loading heavy libraries when not needed (optional feature).

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -187,7 +187,6 @@ class ETL_Base(object):
             self.push_to_kafka(output, self.OUTPUT_TYPES)
         if self.jargs.merged_args.get('register_to_athena') and self.jargs.enable_db_push:
             self.register_to_athena(output)
-            # import ipdb; ipdb.set_trace()
 
         if self.jargs.output.get('df_type', 'spark') == 'spark':
             output.unpersist()
@@ -358,7 +357,6 @@ class ETL_Base(object):
                 path = path.replace('{' + self.jargs.merged_args.get('name_base_in_param') + '}', '{base_path}')
             else:
                 base_path = self.jargs.merged_args['base_path']
-            # import ipdb; ipdb.set_trace()
 
             path = Path_Handler(path, base_path, self.jargs.merged_args.get('root_path')).expand_later()
             self.jargs.inputs[input_name]['path_expanded'] = path
@@ -1060,7 +1058,6 @@ class Path_Handler():
             upstream_path = path.split('{latest}')[0]
             paths = FS_Ops_Dispatcher().listdir(upstream_path)
             latest_date = max(paths)
-            # path = path.format(latest=latest_date)
             path = path.replace('{latest}', latest_date)
         return path
 

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -713,18 +713,19 @@ class ETL_Base(object):
         create_table(sdf, connection_profile, name_tb, schema, creds, self.jargs.is_incremental, self.jargs.redshift_s3_tmp_dir, self.jargs.merged_args.get('spark_version', '3.5'))
 
     def register_to_athena(self, df):
-        from yaetos.athena import register_table, register_table_from_sdf_to_glue
-        from yaetos.db_utils import pandas_types_to_hive_types
+        from yaetos.athena import register_table_from_pdf_to_athena_catalog, register_table_from_sdf_to_glue_catalog
+        from yaetos.db_utils import pandas_types_to_hive_types, spark_types_to_hive_types
         schema, name_tb = self.jargs.register_to_athena['table'].split('.')
         schema = schema.format(schema=self.jargs.schema) if '{schema}' in schema else schema
         output_info = self.jargs.output
         if isinstance(df, pd.DataFrame):
             hive_types = pandas_types_to_hive_types(df)
             args = self.jargs.merged_args
-            register_table(hive_types, name_tb, schema, output_info, args)
+            register_table_from_pdf_to_athena_catalog(hive_types, name_tb, schema, output_info, args)
         else:
+            hive_types = spark_types_to_hive_types(df)
             args = self.jargs.merged_args
-            register_table_from_sdf_to_glue(df, name_tb, schema, output_info, args)
+            register_table_from_sdf_to_glue_catalog(hive_types, name_tb, schema, output_info, args)
 
 
     def copy_to_clickhouse(self, sdf):

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1241,7 +1241,7 @@ class Runner():
         if jargs.merged_args.get('driver-memoryOverhead'):  # For extra overhead for python in driver (typically pandas)
             conf = conf.set("spark.driver.memoryOverhead", jargs.merged_args['driver-memoryOverhead'])
 
-        if 'dev_local' in jargs.mode.split(',')  and jargs.load_connectors == 'all':
+        if 'dev_local' in jargs.mode.split(',') and jargs.load_connectors == 'all':
             # Setup below not needed when running from EMR because setup there is done through spark-submit.
             # Env vars for S3 access
             get_aws_setup(jargs.merged_args)

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -83,7 +83,7 @@ class ETL_Base(object):
             else:
                 output = self.etl_multi_pass(sc, sc_sql, self.loaded_inputs)
         except Exception as err:
-            if self.jargs.mode in ('prod_EMR') and self.jargs.merged_args.get('owners'):
+            if self.jargs.merged_args.get('send_emails') and self.jargs.merged_args.get('owners'):
                 self.send_job_failure_email(err)
             raise Exception("Job failed, error: \n{}".format(err))
         self.out_df = output

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1274,7 +1274,7 @@ class Runner():
 
 def get_aws_setup(args):
     if os.environ.get('AWS_ACCESS_KEY_ID') and os.environ.get('AWS_SECRET_ACCESS_KEY'):
-        session = boto3.Session()  # to check : credentials = session.get_credentials(); print(credentials.access_key); print(credentials.secret_key)
+        session = boto3.Session()  # to check : credentials = session.get_credentials()
         return session
 
     from configparser import ConfigParser

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -1056,7 +1056,8 @@ class Path_Handler():
             upstream_path = path.split('{latest}')[0]
             paths = FS_Ops_Dispatcher().listdir(upstream_path)
             latest_date = max(paths)
-            path = path.format(latest=latest_date)
+            # path = path.format(latest=latest_date)
+            path = path.replace('{latest}', latest_date)
         return path
 
     def expand_now(self, now_dt):

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -349,7 +349,7 @@ class ETL_Base(object):
         input_type = self.jargs.inputs[input_name]['type']
         if input_type in self.FILE_TYPES:
             path = self.jargs.inputs[input_name]['path']
-            path = path.replace('s3://', 's3a://') if self.jargs.mode == 'dev_local' else path
+            path = path.replace('s3://', 's3a://') if 'dev_local' in self.jargs.mode.split(',') else path
             logger.info("Input '{}' to be loaded from files '{}'.".format(input_name, path))
             path = Path_Handler(path, self.jargs.base_path, self.jargs.merged_args.get('root_path')).expand_later()
             self.jargs.inputs[input_name]['path_expanded'] = path
@@ -422,7 +422,7 @@ class ETL_Base(object):
         input = df_meta  # TODO: get 2 variables below from this one.
         input_type = type  # TODO: remove 'input_' prefix in code below since not specific to input.
         input_name = name
-        path = path.replace('s3://', 's3a://') if self.jargs.mode == 'dev_local' else path
+        path = path.replace('s3://', 's3a://') if 'dev_local' in self.jargs.mode.split(',') else path
         logger.info("Dataset '{}' to be loaded from files '{}'.".format(input_name, path))
         path = self.expand_input_path(path, **kwargs)
 
@@ -931,7 +931,7 @@ class Job_Args_Parser():
 
     @staticmethod
     def get_default_mode(args):
-        if args.get('mode') == 'dev_local' and args.get('deploy') in ('EMR', 'EMR_Scheduled', 'airflow'):
+        if args.get('mode') and 'dev_local' in args['mode'].split(',') and args.get('deploy') in ('EMR', 'EMR_Scheduled', 'airflow'):
             return 'dev_EMR'
         else:
             return args.get('mode', 'None')
@@ -1241,7 +1241,7 @@ class Runner():
         if jargs.merged_args.get('driver-memoryOverhead'):  # For extra overhead for python in driver (typically pandas)
             conf = conf.set("spark.driver.memoryOverhead", jargs.merged_args['driver-memoryOverhead'])
 
-        if jargs.mode == 'dev_local' and jargs.load_connectors == 'all':
+        if 'dev_local' in jargs.mode.split(',')  and jargs.load_connectors == 'all':
             # Setup below not needed when running from EMR because setup there is done through spark-submit.
             # Env vars for S3 access
             get_aws_setup(jargs.merged_args)

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -713,7 +713,7 @@ class ETL_Base(object):
         create_table(sdf, connection_profile, name_tb, schema, creds, self.jargs.is_incremental, self.jargs.redshift_s3_tmp_dir, self.jargs.merged_args.get('spark_version', '3.5'))
 
     def register_to_athena(self, df):
-        from yaetos.athena import register_table_from_pdf_to_athena_catalog, register_table_from_sdf_to_glue_catalog
+        from yaetos.athena import register_table_to_glue_catalog  # TODO: add register_table_to_athena_catalog
         from yaetos.db_utils import pandas_types_to_hive_types, spark_types_to_hive_types
         schema, name_tb = self.jargs.register_to_athena['table'].split('.')
         schema = schema.format(schema=self.jargs.schema) if '{schema}' in schema else schema
@@ -721,11 +721,11 @@ class ETL_Base(object):
         if isinstance(df, pd.DataFrame):
             hive_types = pandas_types_to_hive_types(df)
             args = self.jargs.merged_args
-            register_table_from_pdf_to_athena_catalog(hive_types, name_tb, schema, output_info, args)
+            register_table_to_glue_catalog(hive_types, name_tb, schema, output_info, args)
         else:
             hive_types = spark_types_to_hive_types(df)
             args = self.jargs.merged_args
-            register_table_from_sdf_to_glue_catalog(hive_types, name_tb, schema, output_info, args)
+            register_table_to_glue_catalog(hive_types, name_tb, schema, output_info, args)
 
     def copy_to_clickhouse(self, sdf):
         # import put here below to avoid loading heavy libraries when not needed (optional feature).

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -355,7 +355,7 @@ class ETL_Base(object):
             # Get base_path. TODO: centralize
             if self.jargs.merged_args.get('name_base_in_param'):
                 base_path = self.jargs.merged_args[self.jargs.merged_args.get('name_base_in_param')]
-                path = path.replace('{'+self.jargs.merged_args.get('name_base_in_param')+'}', '{base_path}')
+                path = path.replace('{' + self.jargs.merged_args.get('name_base_in_param') + '}', '{base_path}')
             else:
                 base_path = self.jargs.merged_args['base_path']
             # import ipdb; ipdb.set_trace()
@@ -405,15 +405,15 @@ class ETL_Base(object):
         globy = self.jargs.inputs[input_name].get('glob')
         if input_type == 'csv':
             delimiter = self.jargs.merged_args.get('csv_delimiter', ',')
-            path = path+globy if globy else path
+            path = path + globy if globy else path
             sdf = self.sc_sql.read.option("delimiter", delimiter).csv(path, header=True)
             logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
         elif input_type == 'parquet':
-            path = path+globy if globy else path
+            path = path + globy if globy else path
             sdf = self.sc_sql.read.parquet(path)
             logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
         elif input_type == 'json':
-            path = path+globy if globy else path
+            path = path + globy if globy else path
             sdf = self.sc_sql.read.json(path)
             logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
         elif input_type == 'mysql':
@@ -496,7 +496,7 @@ class ETL_Base(object):
         # Get base_path. TODO: centralize
         if self.jargs.merged_args.get('name_base_in_param'):
             base_path = self.jargs.merged_args[self.jargs.merged_args.get('name_base_in_param')]
-            path = path.replace('{'+self.jargs.merged_args.get('name_base_in_param')+'}', '{base_path}')
+            path = path.replace('{' + self.jargs.merged_args.get('name_base_in_param') + '}', '{base_path}')
         else:
             base_path = self.jargs.merged_args['base_path']
 
@@ -507,7 +507,7 @@ class ETL_Base(object):
         # Get base_path. TODO: centralize
         if self.jargs.merged_args.get('name_base_out_param'):
             base_path = self.jargs.merged_args[self.jargs.merged_args.get('name_base_out_param')]
-            path = path.replace('{'+self.jargs.merged_args.get('name_base_out_param')+'}', '{base_path}')
+            path = path.replace('{' + self.jargs.merged_args.get('name_base_out_param') + '}', '{base_path}')
         else:
             base_path = self.jargs.merged_args['base_path']
 
@@ -726,7 +726,6 @@ class ETL_Base(object):
             hive_types = spark_types_to_hive_types(df)
             args = self.jargs.merged_args
             register_table_from_sdf_to_glue_catalog(hive_types, name_tb, schema, output_info, args)
-
 
     def copy_to_clickhouse(self, sdf):
         # import put here below to avoid loading heavy libraries when not needed (optional feature).
@@ -984,7 +983,7 @@ class Job_Args_Parser():
             # Get base_path. TODO: centralize
             if args.get('name_base_in_param'):  # TODO: check if requires name_base_in_param or name_base_out_param
                 base_path = args[args.get('name_base_in_param')]
-                args['spark_app_args'] = args['spark_app_args'].replace('{'+self.jargs.merged_args.get('name_base_in_param')+'}', '{base_path}')
+                args['spark_app_args'] = args['spark_app_args'].replace('{' + self.jargs.merged_args.get('name_base_in_param') + '}', '{base_path}')
             else:
                 base_path = args.get('base_path')
             args['spark_app_args'] = Path_Handler(args['spark_app_args'], base_path, args.get('root_path')).path

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -402,14 +402,18 @@ class ETL_Base(object):
             return pdf
 
         # Tabular types, Spark
+        globy = self.jargs.inputs[input_name].get('glob')
         if input_type == 'csv':
             delimiter = self.jargs.merged_args.get('csv_delimiter', ',')
+            path = path+globy if globy else path
             sdf = self.sc_sql.read.option("delimiter", delimiter).csv(path, header=True)
             logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
         elif input_type == 'parquet':
+            path = path+globy if globy else path
             sdf = self.sc_sql.read.parquet(path)
             logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
         elif input_type == 'json':
+            path = path+globy if globy else path
             sdf = self.sc_sql.read.json(path)
             logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))
         elif input_type == 'mysql':
@@ -613,8 +617,6 @@ class ETL_Base(object):
 
     def save(self, output, path, base_path, type, now_dt=None, is_incremental=None, incremental_type=None, partitionby=None, file_tag=None, **kwargs):
         """Used to save output to disk. Can be used too inside jobs to output 2nd output for testing."""
-        # import ipdb; ipdb.set_trace()
-        # path = Path_Handler(path, base_path, self.jargs.merged_args.get('root_path')).expand_now(now_dt):
         path = self.expand_output_path(path, now_dt, **kwargs)
         self.jargs.output['path_expanded'] = path
 
@@ -1034,6 +1036,7 @@ class Job_Args_Parser():
 
 class Path_Handler():
     def __init__(self, path, base_path=None, root_path=None):
+        # TODO: rewrite full class. too hacky.
         self.path = path
         self.base_path = base_path
         self.root_path = root_path

--- a/yaetos/etl_utils.py
+++ b/yaetos/etl_utils.py
@@ -231,12 +231,26 @@ class ETL_Base(object):
 
     def set_jargs(self, pre_jargs, loaded_inputs={}):
         """ jargs means job args. Function called only if running the job directly, i.e. "python some_job.py"""
+        # Set job_name
         if 'job_name' not in pre_jargs['job_args']:
             py_job = self.set_py_job()
             job_name = Job_Yml_Parser.set_job_name_from_file(py_job)
         else:
             job_name = pre_jargs['job_args']['job_name']
-        return Job_Args_Parser(defaults_args=pre_jargs['defaults_args'], yml_args=None, job_args=pre_jargs['job_args'], cmd_args=pre_jargs['cmd_args'], job_name=job_name, build_yml_args=True, loaded_inputs=loaded_inputs)
+        
+        # Set jargs
+        jargs = Job_Args_Parser(
+            defaults_args=pre_jargs['defaults_args'], 
+            yml_args=None, 
+            job_args=pre_jargs['job_args'], 
+            cmd_args=pre_jargs['cmd_args'], 
+            job_name=job_name, 
+            build_yml_args=True, 
+            loaded_inputs=loaded_inputs)
+
+        # Room for jargs mods at job level.
+        jargs = self.expand_params(jargs)
+        return jargs
 
     def set_py_job(self):
         """ Returns the file being executed. For ex, when running "python some_job.py", this functions returns "some_job.py".
@@ -459,6 +473,10 @@ class ETL_Base(object):
 
         logger.info("Dataset data types: {}".format(pformat([(fd.name, fd.dataType) for fd in sdf.schema.fields])))
         return sdf
+
+    @staticmethod
+    def expand_params(jargs, **kwargs):
+        return jargs
 
     def expand_input_path(self, path, **kwargs):
         # Function call isolated to be overridable.

--- a/yaetos/excel_utils.py
+++ b/yaetos/excel_utils.py
@@ -14,7 +14,7 @@ def load_excel(jargs, input_name, output_types, sc, sc_sql, **xls_args):
 def load_excel_pandas(jargs, input_name, **xls_args):
 
     path = jargs.inputs[input_name]['path']
-    path = path.replace('s3://', 's3a://') if jargs.mode == 'dev_local' else path
+    path = path.replace('s3://', 's3a://') if 'dev_local' in jargs.mode.split(',') else path
     logger.info("Input '{}' to be loaded from files '{}'.".format(input_name, path))
     path = Path_Handler(path, jargs.base_path).expand_later()
     logger.info("Input '{}' loaded from files '{}'.".format(input_name, path))

--- a/yaetos/git_utils.py
+++ b/yaetos/git_utils.py
@@ -10,13 +10,20 @@ class Git_Config_Manager():
     FNAME = 'conf/git_config.yml'
 
     def get_config(self, mode, **kwargs):
-        if mode == 'dev_local':
+
+        # Deal with multiple modes if any (Hacky. TODO: improve) 
+        modes = mode.split(',')
+        required_mode = ('dev_local', 'dev_EMR', 'prod_EMR')
+
+        # if mode == 'dev_local':
+        if 'dev_local' in modes:
             config = self.get_config_from_git(kwargs['local_app_folder'])
             # For debug: self.save_yaml(config)
-        elif mode in ('dev_EMR', 'prod_EMR'):
+        # elif mode in ('dev_EMR', 'prod_EMR'):
+        elif 'dev_EMR' in modes or 'prod_EMR' in modes:
             config = self.get_config_from_file(kwargs['cluster_app_folder'])
         else:
-            raise Exception('Wrong mode')
+            raise Exception(f'Wrong mode, one of the mode should be in {required_mode}')
         return config
 
     def get_config_from_git(self, local_app_folder):

--- a/yaetos/git_utils.py
+++ b/yaetos/git_utils.py
@@ -11,7 +11,7 @@ class Git_Config_Manager():
 
     def get_config(self, mode, **kwargs):
 
-        # Deal with multiple modes if any (Hacky. TODO: improve) 
+        # Deal with multiple modes if any (Hacky. TODO: improve)
         modes = mode.split(',')
         if 'dev_local' in modes:
             config = self.get_config_from_git(kwargs['local_app_folder'])

--- a/yaetos/git_utils.py
+++ b/yaetos/git_utils.py
@@ -13,16 +13,13 @@ class Git_Config_Manager():
 
         # Deal with multiple modes if any (Hacky. TODO: improve) 
         modes = mode.split(',')
-        required_mode = ('dev_local', 'dev_EMR', 'prod_EMR')
-
-        # if mode == 'dev_local':
         if 'dev_local' in modes:
             config = self.get_config_from_git(kwargs['local_app_folder'])
             # For debug: self.save_yaml(config)
-        # elif mode in ('dev_EMR', 'prod_EMR'):
         elif 'dev_EMR' in modes or 'prod_EMR' in modes:
             config = self.get_config_from_file(kwargs['cluster_app_folder'])
         else:
+            required_mode = ('dev_local', 'dev_EMR', 'prod_EMR')
             raise Exception(f'Wrong mode, one of the mode should be in {required_mode}')
         return config
 

--- a/yaetos/libs/generic_jobs/copy_raw_job.py
+++ b/yaetos/libs/generic_jobs/copy_raw_job.py
@@ -1,3 +1,6 @@
+"""
+Job meant to run locally to get data from AWS S3 to local. Updates require to run in cluster.
+"""
 from yaetos.etl_utils import ETL_Base, Commandliner, get_aws_setup
 import os
 from cloudpathlib import CloudPath as CPt

--- a/yaetos/scripts/copy/Dockerfile_external
+++ b/yaetos/scripts/copy/Dockerfile_external
@@ -9,7 +9,7 @@ RUN apt update \
 # 2 lines above for jupyterlab
 
 RUN python -m pip install --upgrade pip
-RUN pip3 install --no-deps yaetos==0.11.7
+RUN pip3 install --no-deps yaetos==0.11.8
 # Force latest version to avoid using previous ones.
 RUN pip3 install -r /opt/bitnami/python/lib/python3.8/site-packages/yaetos/scripts/requirements_base.txt
 # Installing libraries required by Yaetos and more. Using this since requirements_base.txt has exact versions.

--- a/yaetos/scripts/copy/aws_config.cfg.example
+++ b/yaetos/scripts/copy/aws_config.cfg.example
@@ -4,7 +4,9 @@ ec2_key_name         : to_be_filled
 user                 : to_be_filled
 s3_region            : to_be_filled
 ec2_subnet_id        : to_be_filled
-extra_security_gp    : None
+extra_security_gp    : to_be_filled # optional
+emr_ec2_role         : to_be_filled # optional
+emr_role             : to_be_filled # optional
 
 [prod]
 profile_name         : to_be_filled
@@ -12,4 +14,6 @@ ec2_key_name         : to_be_filled
 user                 : to_be_filled
 s3_region            : to_be_filled
 ec2_subnet_id        : to_be_filled
-extra_security_gp    : None
+extra_security_gp    : to_be_filled # optional
+emr_ec2_role         : to_be_filled # optional
+emr_role             : to_be_filled # optional


### PR DESCRIPTION
Added ability to define and use multiple sections in mode_specific_params. Useful for support single tenancy architecture, where data lake is split across buckets.
Involved:
 * New params "name_base_in_param" and "name_base_in_param" to deal with cases when input and output base_path are different. (not ideal yet, to be improved later)
 * New jobs to ex17_multimode_params_job and ex18_base_path_in_out_job
 * new section in mode_specific_params "your_extra_tenant" example
 * new unit-tests 
 * update all cases of hardcoded dev_local, dev_EMR or prod_EMR

Other
 * More code to register to athena, from spark df, and using glue
 * clean and fix setup of spark-submit in EMR steps, to use python launcher.py --job_name instead of using py_job that may not have been registered in jobs_metadata.yml.
 * Made emr_ec2_role and emr_role overrideable.
 * fix to loading pandas df from parquet in AWS (there was pb with individual files and tmp folder)
 * allow expanding params from job, using new expand_params()
 * allow use of glob for loading spark df from various path (regex to be added later) 
 * More flexible way to deal with `*/'{latest}'/` and `*/'{now}'/`
 
Moved to 0.11.8. Published to pypi